### PR TITLE
Matrix manipulation subroutines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Julia environment
         uses: julia-actions/setup-julia@latest
         with:
-          version: 1.6
+          version: 1.7.2
           show-versioninfo: true
 
       # Add the MolSim repository (there must be a better way of doing this)

--- a/src/ACEhamiltonians.jl
+++ b/src/ACEhamiltonians.jl
@@ -25,6 +25,9 @@ include("io.jl")
 include("parameters.jl")
 @reexport using ACEhamiltonians.Parameters
 
+include("data.jl")
+@reexport using ACEhamiltonians.MatrixManipulation
+
 include("struc_setting.jl")
 @reexport using ACEhamiltonians.Structure
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -4,7 +4,7 @@ module MatrixManipulation
 using ACEhamiltonians
 using JuLIP: Atoms
 
-export BlkIdx, atomic_blk_idxs, repeat_atomic_blk_idxs, filter_on_site_idxs,
+export BlkIdx, atomic_block_idxs, repeat_atomic_block_idxs, filter_on_site_idxs,
        filter_off_site_idxs, filter_upper_idxs, filter_lower_idxs, get_sub_blocks,
        set_sub_blocks!, get_blocks, set_blocks!, locate_and_get_sub_blocks
 
@@ -46,7 +46,7 @@ BlkIdx = AbstractMatrix
 # These are the main methods by which `BlkIdx` instances are are constructed & expanded.
 
 """
-    atomic_blk_idxs(z_1, z_2, z_s[; order_invariant=false])
+    atomic_block_idxs(z_1, z_2, z_s[; order_invariant=false])
 
 Construct a block index matrix listing all atomic-blocks present in the supplied system
 where the first and second species are `z_1` and `z_2` respectively.
@@ -55,41 +55,41 @@ where the first and second species are `z_1` and `z_2` respectively.
 - `z_1::Int`: first interacting species
 - `z_2::Int`: second interacting species
 - `z_s::Vector`: atomic numbers present in system
-- `order_invariant::Bool`: by default, `blk_idxs` only indexes atomic blocks in which the
+- `order_invariant::Bool`: by default, `block_idxs` only indexes atomic blocks in which the
   1ˢᵗ & 2ⁿᵈ species are `z_1` & `z_2` respectively. However, if `order_invariant` is enabled
-  then `blk_idxs` will index all atomic blocks between the two species irrespective of
+  then `block_idxs` will index all atomic blocks between the two species irrespective of
   which comes first.
 
 # Returns
-- `blk_idxs::BlkIdx`: a 2×N matrix in which each column represents the index of an atomic block.
-  With `blk_idxs[:, i]` yielding the atomic indices associated with the iᵗʰ atomic-block.
+- `block_idxs::BlkIdx`: a 2×N matrix in which each column represents the index of an atomic block.
+  With `block_idxs[:, i]` yielding the atomic indices associated with the iᵗʰ atomic-block.
 
 # Notes
 Enabling `order_invariant` is analogous to the following compound call:
-`hcat(atomic_blk_idxs(z_1, z_2, z_s), atomic_blk_idxs(z_2, z_1, z_s))`
+`hcat(atomic_block_idxs(z_1, z_2, z_s), atomic_block_idxs(z_2, z_1, z_s))`
 Furthermore, only indices associated with the origin cell are returned; if extra-cellular
-blocks are required then `repeat_atomic_blk_idxs` should be used.
+blocks are required then `repeat_atomic_block_idxs` should be used.
 
 # Examples
 ```
 julia> atomic_numbers = [1, 1, 8]
-julia> atomic_blk_idxs(1, 8, atomic_numbers)
+julia> atomic_block_idxs(1, 8, atomic_numbers)
 2×2 Matrix{Int64}:
  1  2
  3  3
 
-julia> atomic_blk_idxs(8, 1, atomic_numbers)
+julia> atomic_block_idxs(8, 1, atomic_numbers)
 2×2 Matrix{Int64}:
  3  3
  1  2
 
-julia> atomic_blk_idxs(8, 1, atomic_numbers; order_invariant=true)
+julia> atomic_block_idxs(8, 1, atomic_numbers; order_invariant=true)
 2×4 Matrix{Int64}:
  3  3  1  2
  1  2  3  3
 ```
 """
-function atomic_blk_idxs(z_1::I, z_2::I, z_s::Vector; order_invariant::Bool=false) where I<:Integer
+function atomic_block_idxs(z_1::I, z_2::I, z_s::Vector; order_invariant::Bool=false) where I<:Integer
     # This function uses views, slices and reshape operations to construct the block index
     # list rather than an explicitly nested for-loop to reduce speed.
     z_1_idx, z_2_idx = findall(==(z_1), z_s), findall(==(z_2), z_s)
@@ -113,40 +113,40 @@ function atomic_blk_idxs(z_1::I, z_2::I, z_s::Vector; order_invariant::Bool=fals
     return res
 end
 
-function atomic_blk_idxs(z_1, z_2, z_s::Atoms; kwargs...)
-    return atomic_blk_idxs(z_1, z_2, convert(Vector{Int}, z_s.Z); kwargs...)
+function atomic_block_idxs(z_1, z_2, z_s::Atoms; kwargs...)
+    return atomic_block_idxs(z_1, z_2, convert(Vector{Int}, z_s.Z); kwargs...)
 end
 
 
 """
-    repeat_atomic_blk_idxs(blk_idxs, n)
+    repeat_atomic_block_idxs(block_idxs, n)
 
 Repeat the atomic blocks indices `n` times and adds a new row specifying image number.
 This is primarily intended to be used as a way to extend an atom block index list to
 account for periodic images as they present in real-space matrices.
 
 # Arguments
-- `blk_idxs::BlkIdx`: the block indices which are to be expanded.
+- `block_idxs::BlkIdx`: the block indices which are to be expanded.
 
 # Returns
-- `blk_indxs_expanded::BlkIdx`: expanded block indices.
+- `block_indxs_expanded::BlkIdx`: expanded block indices.
 
 # Examples
 ```
-julia> blk_idxs = [10 10 20 20; 10 20 10 20]
-julia> repeat_atomic_blk_idxs(blk_idxs, 2)
+julia> block_idxs = [10 10 20 20; 10 20 10 20]
+julia> repeat_atomic_block_idxs(block_idxs, 2)
 3×8 Matrix{Int64}:
  10  10  20  20  10  10  20  20
  10  20  10  20  10  20  10  20
   1   1   1   1   2   2   2   2
 ```
 """
-function repeat_atomic_blk_idxs(blk_idxs::BlkIdx, n::T) where T<:Integer
-    @assert size(blk_idxs, 1) != 3 "`blk_idxs` has already been expanded."
-    m = size(blk_idxs, 2)
+function repeat_atomic_block_idxs(block_idxs::BlkIdx, n::T) where T<:Integer
+    @assert size(block_idxs, 1) != 3 "`block_idxs` has already been expanded."
+    m = size(block_idxs, 2)
     res = Matrix{T}(undef, 3, m * n)
     @views reshape(res[3, :], (m, n)) .= (1:n)'
-    @views reshape(res[1:2, :], (2, m, n)) .= blk_idxs
+    @views reshape(res[1:2, :], (2, m, n)) .= block_idxs
     return res
 end
 
@@ -157,39 +157,39 @@ end
 # Internal functions that operate on `BlkIdx`.
 
 """
-    _blk_starts(blk_idxs, atoms, basis_def)
+    _block_starts(block_idxs, atoms, basis_def)
 
-This function takes a series of atomic block indices, `blk_idxs`, and returns the index
+This function takes a series of atomic block indices, `block_idxs`, and returns the index
 of the first element in each atomic block. This is helpful when wanting to locate atomic
 blocks in a Hamiltonian or overlap matrix associated with a given pair of atoms.
 
 # Arguments
-- `blk_idxs::BlkIdx`: block indices specifying the blocks whose starts are to be returned.
+- `block_idxs::BlkIdx`: block indices specifying the blocks whose starts are to be returned.
 - `atoms::Atoms`: atoms object of the target system.
 - `basis_def::BasisDef`: corresponding basis set definition.
 
 # Returns
-- `block_starts::Matrix`: A copy of `blk_idxs` where the first & second rows now provide an
+- `block_starts::Matrix`: A copy of `block_idxs` where the first & second rows now provide an
   index specifying where the associated block starts in the Hamiltonian/overlap matrix. The
   third row, if present, is left unchanged.
 """
-function _blk_starts(blk_idxs::BlkIdx, atoms::Atoms, basis_def::BasisDef)
+function _block_starts(block_idxs::BlkIdx, atoms::Atoms, basis_def::BasisDef)
     n_orbs = Dict(k=>sum(2v .+ 1) for (k,v) in basis_def) # N∘ orbitals per species
     n_orbs_per_atom = [n_orbs[z] for z in atoms.Z] # N∘ of orbitals on each atom
-    block_starts = copy(blk_idxs)
+    block_starts = copy(block_idxs)
     @views block_starts[1:2, :] = (
-        cumsum(n_orbs_per_atom) - n_orbs_per_atom .+ 1)[blk_idxs[1:2, :]]
+        cumsum(n_orbs_per_atom) - n_orbs_per_atom .+ 1)[block_idxs[1:2, :]]
 
     return block_starts
 end
 
 """
-    _sblk_starts(z_1, z_2, s_i, s_j, basis_def)
+    _sub_block_starts(z_1, z_2, s_i, s_j, basis_def)
 
 
 Get the index of the first element of the sub-block formed between shells `s_i` and `s_j`
 of species `z_1` and `z_2` respectively. The results of this method are commonly added to
-those of `_blk_starts` to give the first index of a desired sub-block in some arbitrary
+those of `_block_starts` to give the first index of a desired sub-block in some arbitrary
 Hamiltonian or overlap matrix.
 
 # Arguments
@@ -200,15 +200,15 @@ Hamiltonian or overlap matrix.
 - `basis_def::BasisDef`: corresponding basis set definition.
 
 # Returns
-- `sblk_starts::Vector`: vector specifying the index in a `z_1`-`z_2` atom-block at which
+- `sub_block_starts::Vector`: vector specifying the index in a `z_1`-`z_2` atom-block at which
   the first element of the `s_i`-`s_j` sub-block is found.
 
 """
-function _sblk_starts(z_1, z_2, s_i::I, s_j::I, basis_def::BasisDef) where I<:Integer
-    sblk_starts = Vector{I}(undef, 2)
-    sblk_starts[1] = sum(2basis_def[z_1][1:s_i-1] .+ 1) + 1
-    sblk_starts[2] = sum(2basis_def[z_2][1:s_j-1] .+ 1) + 1
-    return sblk_starts
+function _sub_block_starts(z_1, z_2, s_i::I, s_j::I, basis_def::BasisDef) where I<:Integer
+    sub_block_starts = Vector{I}(undef, 2)
+    sub_block_starts[1] = sum(2basis_def[z_1][1:s_i-1] .+ 1) + 1
+    sub_block_starts[2] = sum(2basis_def[z_2][1:s_j-1] .+ 1) + 1
+    return sub_block_starts
 end
 
 
@@ -219,79 +219,79 @@ end
 # indices or collections thereof. 
 
 """
-    filter_on_site_idxs(blk_idxs)
+    filter_on_site_idxs(block_idxs)
 
 Filter out all but the on-site block indices.
 
 # Arguments
-- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+- `block_idxs::BlkIdx`: block index matrix to be filtered.
 
 # Returns
-- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only on-site block indices remaining.
+- `filtered_block_idxs::BlkIdx`: copy of `block_idxs` with only on-site block indices remaining.
 
 """
-function filter_on_site_idxs(blk_idxs::BlkIdx)
-    # When `blk_idxs` is a 2×N matrix then the only requirement for an interaction to be
-    # on-site is that the two atomic indices are equal to one another. If `blk_idxs` is a
+function filter_on_site_idxs(block_idxs::BlkIdx)
+    # When `block_idxs` is a 2×N matrix then the only requirement for an interaction to be
+    # on-site is that the two atomic indices are equal to one another. If `block_idxs` is a
     # 3×N matrix then the interaction must lie within the origin cell.
-    if size(blk_idxs, 1) == 2
-        return blk_idxs[:, blk_idxs[1, :] .≡ blk_idxs[2, :]]
+    if size(block_idxs, 1) == 2
+        return block_idxs[:, block_idxs[1, :] .≡ block_idxs[2, :]]
     else 
-        return blk_idxs[:, blk_idxs[1, :] .≡ blk_idxs[2, :] .&& blk_idxs[3, :] .== 1]
+        return block_idxs[:, block_idxs[1, :] .≡ block_idxs[2, :] .&& block_idxs[3, :] .== 1]
     end
 end
 
 """
-    filter_off_site_idxs(blk_idxs)
+    filter_off_site_idxs(block_idxs)
 
 Filter out all but the off-site block indices.
 
 # Arguments
-- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+- `block_idxs::BlkIdx`: block index matrix to be filtered.
 
 # Returns
-- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only off-site block indices remaining.
+- `filtered_block_idxs::BlkIdx`: copy of `block_idxs` with only off-site block indices remaining.
 
 """
-function filter_off_site_idxs(blk_idxs::BlkIdx)
-    if size(blk_idxs, 1) == 2  # Locate where atomic indices not are equal
-        return blk_idxs[:, blk_idxs[1, :] .≠ blk_idxs[2, :]]
+function filter_off_site_idxs(block_idxs::BlkIdx)
+    if size(block_idxs, 1) == 2  # Locate where atomic indices not are equal
+        return block_idxs[:, block_idxs[1, :] .≠ block_idxs[2, :]]
     else  # Find where atomic indices are not equal or the cell≠1.
-        return blk_idxs[:, blk_idxs[1, :] .≠ blk_idxs[2, :] .|| blk_idxs[3, :] .≠ 1]
+        return block_idxs[:, block_idxs[1, :] .≠ block_idxs[2, :] .|| block_idxs[3, :] .≠ 1]
     end
 end
 
 
 """
-    filter_upper_idxs(blk_idxs)
+    filter_upper_idxs(block_idxs)
 
 Filter out atomic-blocks that reside in the lower triangle of the matrix. This is useful
 for removing duplicate data in some cases. (blocks on the diagonal are retained)
 
 # Arguments
-- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+- `block_idxs::BlkIdx`: block index matrix to be filtered.
 
 # Returns
-- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only blocks from the upper
+- `filtered_block_idxs::BlkIdx`: copy of `block_idxs` with only blocks from the upper
    triangle remaining.
 """
-filter_upper_idxs(blk_idxs::BlkIdx) = blk_idxs[:, blk_idxs[1, :] .≤ blk_idxs[2, :]]
+filter_upper_idxs(block_idxs::BlkIdx) = block_idxs[:, block_idxs[1, :] .≤ block_idxs[2, :]]
 
 
 """
-    filter_lower_idxs(blk_idxs)
+    filter_lower_idxs(block_idxs)
 
 Filter out atomic-blocks that reside in the upper triangle of the matrix. This is useful
 for removing duplicate data in some cases. (blocks on the diagonal are retained)
 
 # Arguments
-- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+- `block_idxs::BlkIdx`: block index matrix to be filtered.
 
 # Returns
-- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only blocks from the lower
+- `filtered_block_idxs::BlkIdx`: copy of `block_idxs` with only blocks from the lower
    triangle remaining.
 """
-filter_lower_idxs(blk_idxs::BlkIdx) = blk_idxs[:, blk_idxs[1, :] .≥ blk_idxs[2, :]]
+filter_lower_idxs(block_idxs::BlkIdx) = block_idxs[:, block_idxs[1, :] .≥ block_idxs[2, :]]
 
 
 # ╭─────────────────────┬─────────────────╮
@@ -406,18 +406,18 @@ end
 
 
 """
-    get_sub_blocks(matrix, blk_idxs, s_i, s_j, atoms, basis_def)
+    get_sub_blocks(matrix, block_idxs, s_i, s_j, atoms, basis_def)
 
 Collect sub-blocks of a given type from select atom-blocks in a provided matrix.
 
 This method will collect, from `matrix`, the `s_i`-`s_j` sub-block of each atom-block
-listed in `blk_idxs`. It is assumed that all atom-blocks are between identical pairs
+listed in `block_idxs`. It is assumed that all atom-blocks are between identical pairs
 of species.
 
 # Arguments
 - `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
   or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
-- `blk_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
+- `block_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
 - `s_i::Int`: first shell
 - `s_j::Int`: second shell
 - `atoms::Atoms`: target system's `JuLIP.Atoms` objects
@@ -430,17 +430,17 @@ of species.
 If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
 the origin cell is first.
 """
-function get_sub_blocks(matrix::AbstractArray{T}, blk_idxs::BlkIdx, s_i, s_j, atoms::Atoms, basis_def) where T
-    z_1, z_2 = atoms.Z[blk_idxs[1:2, 1]]
+function get_sub_blocks(matrix::AbstractArray{T}, block_idxs::BlkIdx, s_i, s_j, atoms::Atoms, basis_def) where T
+    z_1, z_2 = atoms.Z[block_idxs[1:2, 1]]
 
     # Identify where each target block starts (first column and row)
-    starts = _blk_starts(blk_idxs, atoms, basis_def)
+    starts = _block_starts(block_idxs, atoms, basis_def)
 
     # Shift `starts` so it points to the start of the **sub-blocks** rather than the block
-    starts[1:2, :] .+= _sblk_starts(z_1, z_2, s_i, s_j, basis_def) .- 1
+    starts[1:2, :] .+= _sub_block_starts(z_1, z_2, s_i, s_j, basis_def) .- 1
 
     data = Array{T, 3}(  # Array in which the resulting sub-blocks are to be collected
-        undef, 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1, size(blk_idxs, 2))
+        undef, 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1, size(block_idxs, 2))
     
     # Carry out the assignment operation.
     _get_blocks!(matrix, data, starts)
@@ -450,17 +450,17 @@ end
 
 
 """
-    set_sub_blocks(matrix, values, blk_idxs, s_i, s_j, atoms, basis_def)
+    set_sub_blocks(matrix, values, block_idxs, s_i, s_j, atoms, basis_def)
 
 Place sub-block data from `values` representing the interaction between shells `s_i` &
-`s_j` into the matrix at the atom-blocks listed in `blk_idxs`. This is this performs
+`s_j` into the matrix at the atom-blocks listed in `block_idxs`. This is this performs
 the inverse operation to `set_sub_blocks`.
 
 # Arguments
 - `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
   or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
 - `values::Array`: sub-block values.
-- `blk_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
+- `block_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
 - `s_i::Int`: first shell
 - `s_j::Int`: second shell
 - `atoms::Atoms`: target system's `JuLIP.Atoms` objects
@@ -470,20 +470,20 @@ the inverse operation to `set_sub_blocks`.
 If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
 the origin cell is first.
 """
-function set_sub_blocks!(matrix::AbstractArray, values, blk_idxs::BlkIdx, s_i, s_j, atoms::Atoms, basis_def)
+function set_sub_blocks!(matrix::AbstractArray, values, block_idxs::BlkIdx, s_i, s_j, atoms::Atoms, basis_def)
     
-    if size(values, 3) != size(blk_idxs, 2)
+    if size(values, 3) != size(block_idxs, 2)
         throw(DimensionMismatch(
-            "The last dimensions of `values` & `blk_idxs` must be of the same length."))
+            "The last dimensions of `values` & `block_idxs` must be of the same length."))
     end
     
-    z_1, z_2 = atoms.Z[blk_idxs[1:2, 1]]
+    z_1, z_2 = atoms.Z[block_idxs[1:2, 1]]
 
     # Identify where each target block starts (first column and row)
-    starts = _blk_starts(blk_idxs, atoms, basis_def)
+    starts = _block_starts(block_idxs, atoms, basis_def)
 
     # Shift `starts` so it points to the start of the **sub-blocks** rather than the block
-    starts[1:2, :] .+= _sblk_starts(z_1, z_2, s_i, s_j, basis_def) .- 1
+    starts[1:2, :] .+= _sub_block_starts(z_1, z_2, s_i, s_j, basis_def) .- 1
 
     # Carry out the scatter operation.
     _set_blocks!(values, matrix, starts)
@@ -491,14 +491,14 @@ end
 
 
 """
-    get_blocks(matrix, blk_idxs, atoms, basis_def)
+    get_blocks(matrix, block_idxs, atoms, basis_def)
 
-Collect, from `matrix`, the blocks listed in `blk_idxs`.
+Collect, from `matrix`, the blocks listed in `block_idxs`.
 
 # Arguments
 - `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
   or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
-- `blk_idxs::BlkIdx`: the atomic-blocks to gathered.
+- `block_idxs::BlkIdx`: the atomic-blocks to gathered.
 - `atoms::Atoms`: target system's `JuLIP.Atoms` objects
 - `basis_def:BasisDef`: corresponding basis set definition object (`BasisDef`)
 
@@ -509,14 +509,14 @@ Collect, from `matrix`, the blocks listed in `blk_idxs`.
 If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
 the origin cell is first.
 """
-function get_blocks(matrix::AbstractArray{T}, blk_idxs::BlkIdx, atoms::Atoms, basis_def) where T
-    z_1, z_2 = atoms.Z[blk_idxs[1:2, 1]]
+function get_blocks(matrix::AbstractArray{T}, block_idxs::BlkIdx, atoms::Atoms, basis_def) where T
+    z_1, z_2 = atoms.Z[block_idxs[1:2, 1]]
 
     # Identify where each target block starts (first column and row)
-    starts = _blk_starts(blk_idxs, atoms, basis_def)
+    starts = _block_starts(block_idxs, atoms, basis_def)
 
     data = Array{T, 3}(  # Array in which the resulting blocks are to be collected
-        undef, sum(2basis_def[z_1].+ 1), sum(2basis_def[z_2].+ 1), size(blk_idxs, 2))
+        undef, sum(2basis_def[z_1].+ 1), sum(2basis_def[z_2].+ 1), size(block_idxs, 2))
     
     # Carry out the assignment operation.
     _get_blocks!(matrix, data, starts)
@@ -526,16 +526,16 @@ end
 
 
 """
-    set_sub_blocks(matrix, values, blk_idxs, s_i, s_j, atoms, basis_def)
+    set_sub_blocks(matrix, values, block_idxs, s_i, s_j, atoms, basis_def)
 
-Place atom-block data from `values` into the matrix at the atom-blocks listed in `blk_idxs`.
+Place atom-block data from `values` into the matrix at the atom-blocks listed in `block_idxs`.
 This is this performs the inverse operation to `set_blocks`.
 
 # Arguments
 - `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
   or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
 - `values::Array`: sub-block values.
-- `blk_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
+- `block_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
 - `s_i::Int`: first shell
 - `s_j::Int`: second shell
 - `atoms::Atoms`: target system's `JuLIP.Atoms` objects
@@ -545,15 +545,15 @@ This is this performs the inverse operation to `set_blocks`.
 If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
 the origin cell is first.
 """
-function set_blocks!(matrix::AbstractArray, values, blk_idxs::BlkIdx, atoms::Atoms, basis_def)
+function set_blocks!(matrix::AbstractArray, values, block_idxs::BlkIdx, atoms::Atoms, basis_def)
 
-    if size(values, 3) != size(blk_idxs, 2)
+    if size(values, 3) != size(block_idxs, 2)
         throw(DimensionMismatch(
-            "The last dimensions of `values` & `blk_idxs` must be of the same length."))
+            "The last dimensions of `values` & `block_idxs` must be of the same length."))
     end
 
     # Identify where each target block starts (first column and row)
-    starts = _blk_starts(blk_idxs, atoms, basis_def)
+    starts = _block_starts(block_idxs, atoms, basis_def)
 
     # Carry out the scatter operation.
     _set_blocks!(values, matrix, starts)
@@ -580,8 +580,8 @@ between the `s_i`'th shell on species `z_1` and the `s_j`'th shell on species `z
 - `sub_blocks`: an Nᵢ×Nⱼ×M array containing the collected sub-blocks; where Nᵢ & Nⱼ are
   the number of orbitals on the `s_i`'th & `s_j`'th shells of species `z_1` & `z_2`
   respectively, and M is the N∘ of sub-blocks found.
-- `blk_idxs`: A matrix specifying which atomic block each sub-block in `sub_blocks`
-  was taken from. If `matrix` is a 3D real space matrix then `blk_idxs` will also
+- `block_idxs`: A matrix specifying which atomic block each sub-block in `sub_blocks`
+  was taken from. If `matrix` is a 3D real space matrix then `block_idxs` will also
   include the cell index.
 
 # Notes
@@ -609,8 +609,8 @@ between the `s_i`'th & `s_j`'th shells on species `z`.
 - `sub_blocks`: an Nᵢ×Nⱼ×M array containing the collected sub-blocks; where Nᵢ & Nⱼ are
   the number of orbitals on the `s_i`'th & `s_j`'th shells of species `z_1` & `z_2`
   respectively, and M is the N∘ of sub-blocks found.
-- `blk_idxs`: A matrix specifying which atomic block each sub-block in `sub_blocks`
-  was taken from. If `matrix` is a 3D real space matrix then `blk_idxs` will also
+- `block_idxs`: A matrix specifying which atomic block each sub-block in `sub_blocks`
+  was taken from. If `matrix` is a 3D real space matrix then `block_idxs` will also
   include the cell index.
 
 # Notes
@@ -620,44 +620,44 @@ the origin cell is first.
 locate_and_get_sub_blocks(matrix, z, s_i, s_j, atoms::Atoms, basis_def) = _locate_and_get_sub_blocks(matrix, z, s_i, s_j, atoms, basis_def)
 
 # Multiple dispatch is used to avoid the type instability in `locate_and_get_sub_blocks`
-# associated with the creation of the `blk_idxs` variable. It is also used to help
+# associated with the creation of the `block_idxs` variable. It is also used to help
 # distinguish between on-site and off-site collection operations. The following
-# `_locate_and_get_sub_blocks` functions differ only in how they construct `blk_idxs`.
+# `_locate_and_get_sub_blocks` functions differ only in how they construct `block_idxs`.
 
 # Off site _locate_and_get_sub_blocks functions
 function _locate_and_get_sub_blocks(matrix::AbstractArray{T, 2}, z_1, z_2, s_i, s_j, atoms::Atoms, basis_def) where T
-    blk_idxs = atomic_blk_idxs(z_1, z_2, atoms.Z)
-    blk_idxs = filter_off_site_idxs(blk_idxs)
+    block_idxs = atomic_block_idxs(z_1, z_2, atoms.Z)
+    block_idxs = filter_off_site_idxs(block_idxs)
     # Duplicate blocks present when gathering off-site homo-atomic homo-orbital interactions
     # must be purged. 
     if (z_1 == z_2) && (s_i == s_j)
-        blk_idxs = filter_upper_idxs(blk_idxs) 
+        block_idxs = filter_upper_idxs(block_idxs) 
     end
-    return get_sub_blocks(matrix, blk_idxs, s_i, s_j, atoms, basis_def), blk_idxs
+    return get_sub_blocks(matrix, block_idxs, s_i, s_j, atoms, basis_def), block_idxs
 end
 
 function _locate_and_get_sub_blocks(matrix::AbstractArray{T, 3}, z_1, z_2, s_i, s_j, atoms::Atoms, basis_def) where T
-    blk_idxs = atomic_blk_idxs(z_1, z_2, atoms.Z)
-    blk_idxs = repeat_atomic_blk_idxs(blk_idxs, size(matrix, 3))
-    blk_idxs = filter_off_site_idxs(blk_idxs)
+    block_idxs = atomic_block_idxs(z_1, z_2, atoms.Z)
+    block_idxs = repeat_atomic_block_idxs(block_idxs, size(matrix, 3))
+    block_idxs = filter_off_site_idxs(block_idxs)
     if (z_1 == z_2) && (s_i == s_j)
-        blk_idxs = filter_upper_idxs(blk_idxs) 
+        block_idxs = filter_upper_idxs(block_idxs) 
     end
-    return get_sub_blocks(matrix, blk_idxs, s_i, s_j, atoms, basis_def), blk_idxs
+    return get_sub_blocks(matrix, block_idxs, s_i, s_j, atoms, basis_def), block_idxs
 end
 
 # On site _locate_and_get_sub_blocks functions
 function _locate_and_get_sub_blocks(matrix::AbstractArray{T, 2}, z, s_i, s_j, atoms::Atoms, basis_def) where T
-    blk_idxs = atomic_blk_idxs(z, z, atoms.Z)
-    blk_idxs = filter_on_site_idxs(blk_idxs)
-    return get_sub_blocks(matrix, blk_idxs, s_i, s_j, atoms, basis_def), blk_idxs
+    block_idxs = atomic_block_idxs(z, z, atoms.Z)
+    block_idxs = filter_on_site_idxs(block_idxs)
+    return get_sub_blocks(matrix, block_idxs, s_i, s_j, atoms, basis_def), block_idxs
 end
 
 function _locate_and_get_sub_blocks(matrix::AbstractArray{T, 3}, z, s_i, s_j, atoms::Atoms, basis_def) where T
-    blk_idxs = atomic_blk_idxs(z, z, atoms.Z)
-    blk_idxs = filter_on_site_idxs(blk_idxs)
-    blk_idxs = repeat_atomic_blk_idxs(blk_idxs, 1)
-    return get_sub_blocks(matrix, blk_idxs, s_i, s_j, atoms, basis_def), blk_idxs
+    block_idxs = atomic_block_idxs(z, z, atoms.Z)
+    block_idxs = filter_on_site_idxs(block_idxs)
+    block_idxs = repeat_atomic_block_idxs(block_idxs, 1)
+    return get_sub_blocks(matrix, block_idxs, s_i, s_j, atoms, basis_def), block_idxs
 end
 
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -1,0 +1,560 @@
+
+
+module MatrixManipulation
+using ACEhamiltonians
+using JuLIP: Atoms
+
+export BlkIdx, atomic_blk_idxs, repeat_atomic_blk_idxs, filter_on_site_idxs, filter_off_site_idxs, filter_upper_idxs, filter_lower_idxs, get_sub_blocks, set_sub_blocks!, get_blocks, set_blocks!
+
+# ╔═════════════════════╗
+# ║ Matrix Manipulation ║
+# ╚═════════════════════╝
+
+# ╭─────────────────────┬────────╮
+# │ Matrix Manipulation │ BlkIdx │
+# ╰─────────────────────┴────────╯
+"""
+An alias for `AbstractMatrix` used to signify a block index matrix. Given the frequency &
+significance of block index matrices it became prudent to create an alias for it. This
+helps to i) make it clear when and where a block index is used and ii) prevent having to
+repeatedly explained what a block index matrix was each time one was used.
+
+As the name suggests, these are matrices which specifies the indices of a series of atomic
+blocks. The 1ˢᵗ row specifies the atomic indices of the 1ˢᵗ atom in each block and the 2ⁿᵈ
+row the indices of the 2ⁿᵈ atom. That is to say `block_index_matrix[:,i]` would yield the
+atomic indices of the atoms associated with the iᵗʰ block listed in `block_index_matrix`.
+The 3ʳᵈ row, if present, specifies the index of the cell in in which the second atom lies;
+i.e. it indexes the cell translation vector list.
+
+For example; `BlkIdx([1 3; 2 4])` specifies two atomic blocks, the first being between
+atoms 1&2, and the second between atoms 3&4; `BlkIdx([5; 6; 10])` represents the atomic
+block between atoms 5&6, however in this case there is a third number 10 which give the
+cell number. The cell number is can be used to help 3D real-space matrices or indicate
+which cell translation vector should be applied.
+
+It is important to note that the majority of functions that take `BlkIdx` as an argument
+will assume the first and second species are consistent across all atomic-blocks. 
+"""
+BlkIdx = AbstractMatrix
+
+
+# ╭─────────────────────┬─────────────────────╮
+# │ Matrix Manipulation │ BlkIdx:Constructors │
+# ╰─────────────────────┴─────────────────────╯
+# These are the main methods by which `BlkIdx` instances are are constructed & expanded.
+
+"""
+    atomic_blk_idxs(z_1, z_2, z_s[; order_invariant=false])
+
+Construct a block index matrix listing all atomic-blocks present in the supplied system
+where the first and second species are `z_1` and `z_2` respectively.
+
+# Arguments
+- `z_1::Int`: first interacting species
+- `z_2::Int`: second interacting species
+- `z_s::Vector`: atomic numbers present in system
+- `order_invariant::Bool`: by default, `blk_idxs` only indexes atomic blocks in which the
+  1ˢᵗ & 2ⁿᵈ species are `z_1` & `z_2` respectively. However, if `order_invariant` is enabled
+  then `blk_idxs` will index all atomic blocks between the two species irrespective of
+  which comes first.
+
+# Returns
+- `blk_idxs::BlkIdx`: a 2×N matrix in which each column represents the index of an atomic block.
+  With `blk_idxs[:, i]` yielding the atomic indices associated with the iᵗʰ atomic-block.
+
+# Notes
+Enabling `order_invariant` is analogous to the following compound call:
+`hcat(atomic_blk_idxs(z_1, z_2, z_s), atomic_blk_idxs(z_2, z_1, z_s))`
+Furthermore, only indices associated with the origin cell are returned; if extra-cellular
+blocks are required then `repeat_atomic_blk_idxs` should be used.
+
+# Examples
+```
+julia> atomic_numbers = [1, 1, 8]
+julia> atomic_blk_idxs(1, 8, atomic_numbers)
+2×2 Matrix{Int64}:
+ 1  2
+ 3  3
+
+julia> atomic_blk_idxs(8, 1, atomic_numbers)
+2×2 Matrix{Int64}:
+ 3  3
+ 1  2
+
+julia> atomic_blk_idxs(8, 1, atomic_numbers; order_invariant=true)
+2×4 Matrix{Int64}:
+ 3  3  1  2
+ 1  2  3  3
+```
+"""
+function atomic_blk_idxs(z_1::I, z_2::I, z_s::Vector; order_invariant::Bool=false) where I<:Integer
+    # This function uses views, slices and reshape operations to construct the block index
+    # list rather than an explicitly nested for-loop to reduce speed.
+    z_1_idx, z_2_idx = findall(==(z_1), z_s), findall(==(z_2), z_s)
+    n, m = length(z_1_idx), length(z_2_idx)
+    if z_1 ≠ z_2 && order_invariant
+        res = Matrix{I}(undef, 2, n * m * 2)
+        @views let res = res[:, 1:end ÷ 2]
+            @views reshape(res[1, :], (m, n)) .= z_1_idx'
+            @views reshape(res[2, :], (m, n)) .= z_2_idx
+        end
+
+        @views let res = res[:, 1 + end ÷ 2:end]
+            @views reshape(res[1, :], (n, m)) .= z_2_idx'
+            @views reshape(res[2, :], (n, m)) .= z_1_idx
+        end
+    else
+        res = Matrix{I}(undef, 2, n * m)
+        @views reshape(res[1, :], (m, n)) .= z_1_idx'
+        @views reshape(res[2, :], (m, n)) .= z_2_idx
+    end
+    return res
+end
+
+function atomic_blk_idxs(z_1, z_2, z_s::Atoms; kwargs...)
+    return atomic_blk_idxs(z_1, z_2, convert(Vector{Int}, z_s.Z); kwargs...)
+end
+
+
+"""
+    repeat_atomic_blk_idxs(blk_idxs, n)
+
+Repeat the atomic blocks indices `n` times and adds a new row specifying image number.
+This is primarily intended to be used as a way to extend an atom block index list to
+account for periodic images as they present in real-space matrices.
+
+# Arguments
+- `blk_idxs::BlkIdx`: the block indices which are to be expanded.
+
+# Returns
+- `blk_indxs_expanded::BlkIdx`: expanded block indices.
+
+# Examples
+```
+julia> blk_idxs = [10 10 20 20; 10 20 10 20]
+julia> repeat_atomic_blk_idxs(blk_idxs, 2)
+3×8 Matrix{Int64}:
+ 10  10  20  20  10  10  20  20
+ 10  20  10  20  10  20  10  20
+  1   1   1   1   2   2   2   2
+```
+"""
+function repeat_atomic_blk_idxs(blk_idxs::BlkIdx, n::T) where T<:Integer
+    @assert size(blk_idxs, 1) != 3 "`blk_idxs` has already been expanded."
+    m = size(blk_idxs, 2)
+    res = Matrix{T}(undef, 3, m * n)
+    @views reshape(res[3, :], (m, n)) .= (1:n)'
+    @views reshape(res[1:2, :], (2, m, n)) .= blk_idxs
+    return res
+end
+
+
+# ╭─────────────────────┬──────────────────╮
+# │ Matrix Manipulation │ BlkIdx:Ancillary │
+# ╰─────────────────────┴──────────────────╯
+# Internal functions that operate on `BlkIdx`.
+
+"""
+    _blk_starts(blk_idxs, atoms, basis_def)
+
+This function takes a series of atomic block indices, `blk_idxs`, and returns the index
+of the first element in each atomic block. This is helpful when wanting to locate atomic
+blocks in a Hamiltonian or overlap matrix associated with a given pair of atoms.
+
+# Arguments
+- `blk_idxs::BlkIdx`: block indices specifying the blocks whose starts are to be returned.
+- `atoms::Atoms`: atoms object of the target system.
+- `basis_def::BasisDef`: corresponding basis set definition.
+
+# Returns
+- `block_starts::Matrix`: A copy of `blk_idxs` where the first & second rows now provide an
+  index specifying where the associated block starts in the Hamiltonian/overlap matrix. The
+  third row, if present, is left unchanged.
+"""
+function _blk_starts(blk_idxs::BlkIdx, atoms::Atoms, basis_def::BasisDef)
+    n_orbs = Dict(k=>sum(2v .+ 1) for (k,v) in basis_def) # N∘ orbitals per species
+    n_orbs_per_atom = [n_orbs[z] for z in atoms.Z] # N∘ of orbitals on each atom
+    block_starts = copy(blk_idxs)
+    @views block_starts[1:2, :] = (
+        cumsum(n_orbs_per_atom) - n_orbs_per_atom .+ 1)[blk_idxs[1:2, :]]
+
+    return block_starts
+end
+
+"""
+    _sblk_starts(z_1, z_2, s_i, s_j, basis_def)
+
+
+Get the index of the first element of the sub-block formed between shells `s_i` and `s_j`
+of species `z_1` and `z_2` respectively. The results of this method are commonly added to
+those of `_blk_starts` to give the first index of a desired sub-block in some arbitrary
+Hamiltonian or overlap matrix.
+
+# Arguments
+- `z_1::Int`: species on which shell `s_i` resides.
+- `z_2::Int`: species on which shell `s_j` resides.
+- `s_i::Int`: first shell of the sub-block.
+- `s_j::Int`: second shell of the sub-block.
+- `basis_def::BasisDef`: corresponding basis set definition.
+
+# Returns
+- `sblk_starts::Vector`: vector specifying the index in a `z_1`-`z_2` atom-block at which
+  the first element of the `s_i`-`s_j` sub-block is found.
+
+"""
+function _sblk_starts(z_1, z_2, s_i::I, s_j::I, basis_def::BasisDef) where I<:Integer
+    sblk_starts = Vector{I}(undef, 2)
+    sblk_starts[1] = sum(2basis_def[z_1][1:s_i-1] .+ 1) + 1
+    sblk_starts[2] = sum(2basis_def[z_2][1:s_j-1] .+ 1) + 1
+    return sblk_starts
+end
+
+
+# ╭─────────────────────┬────────────────╮
+# │ Matrix Manipulation │ BlkIdx:Filters │
+# ╰─────────────────────┴────────────────╯
+# Filtering operators to help with differentiating between and selecting specific block
+# indices or collections thereof. 
+
+"""
+    filter_on_site_idxs(blk_idxs)
+
+Filter out all but the on-site block indices.
+
+# Arguments
+- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+
+# Returns
+- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only on-site block indices remaining.
+
+"""
+function filter_on_site_idxs(blk_idxs::BlkIdx)
+    # When `blk_idxs` is a 2×N matrix then the only requirement for an interaction to be
+    # on-site is that the two atomic indices are equal to one another. If `blk_idxs` is a
+    # 3×N matrix then the interaction must lie within the origin cell.
+    if size(blk_idxs, 1) == 2
+        return blk_idxs[:, blk_idxs[1, :] .≡ blk_idxs[2, :]]
+    else 
+        return blk_idxs[:, blk_idxs[1, :] .≡ blk_idxs[2, :] .&& blk_idxs[3, :] .== 1]
+    end
+end
+
+"""
+    filter_off_site_idxs(blk_idxs)
+
+Filter out all but the off-site block indices.
+
+# Arguments
+- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+
+# Returns
+- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only off-site block indices remaining.
+
+"""
+function filter_off_site_idxs(blk_idxs::BlkIdx)
+    if size(blk_idxs, 1) == 2  # Locate where atomic indices not are equal
+        return blk_idxs[:, blk_idxs[1, :] .≠ blk_idxs[2, :]]
+    else  # Find where atomic indices are not equal or the cell≠1.
+        return blk_idxs[:, blk_idxs[1, :] .≠ blk_idxs[2, :] .|| blk_idxs[3, :] .≠ 1]
+    end
+end
+
+
+"""
+    filter_upper_idxs(blk_idxs)
+
+Filter out atomic-blocks that reside in the lower triangle of the matrix. This is useful
+for removing duplicate data in some cases. (blocks on the diagonal are retained)
+
+# Arguments
+- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+
+# Returns
+- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only blocks from the upper
+   triangle remaining.
+"""
+filter_upper_idxs(blk_idxs::BlkIdx) = blk_idxs[:, blk_idxs[1, :] .≤ blk_idxs[2, :]]
+
+
+"""
+    filter_lower_idxs(blk_idxs)
+
+Filter out atomic-blocks that reside in the upper triangle of the matrix. This is useful
+for removing duplicate data in some cases. (blocks on the diagonal are retained)
+
+# Arguments
+- `blk_idxs::BlkIdx`: block index matrix to be filtered.
+
+# Returns
+- `filtered_blk_idxs::BlkIdx`: copy of `blk_idxs` with only blocks from the lower
+   triangle remaining.
+"""
+filter_lower_idxs(blk_idxs::BlkIdx) = blk_idxs[:, blk_idxs[1, :] .≥ blk_idxs[2, :]]
+
+
+# ╭─────────────────────┬─────────────────╮
+# │ Matrix Manipulation │ Data Assignment │
+# ╰─────────────────────┴─────────────────╯
+
+# The `_get_blocks!` methods are used to collect either atomic-blocks or sub-blocks from
+# a Hamiltonian or overlap matrix.
+
+"""
+    _get_blocks!(src, target, starts)
+
+Gather blocks from a `src` matrix and store them in the array `target`. This method is
+to be used when gathering data from two-dimensional, single k-point, matrices. 
+
+# Arguments
+- `src::Matrix`: matrix from which data is to be drawn.
+- `target::Array`: array in which data should be stored.
+- `starts::BlkIdx`: a matrix specifying where each target block starts.
+
+# Notes
+The size of each block to ge gathered is worked out form the size of `target`.
+
+"""
+function _get_blocks!(src::Matrix{T}, target::AbstractArray{T, 3}, starts::BlkIdx) where T
+    for i in 1:size(starts, 2)
+        @views target[:, :, i] = src[
+            starts[1, i]:starts[1, i] + size(target, 1) - 1,
+            starts[2, i]:starts[2, i] + size(target, 2) - 1]
+    end
+end
+
+"""
+    _get_blocks!(src, target, starts)
+
+Gather blocks from a `src` matrix and store them in the array `target`. This method is
+to be used when gathering data from three-dimensional, real-space, matrices.
+
+# Arguments
+- `src::Matrix`: matrix from which data is to be drawn.
+- `target::Array`: array in which data should be stored.
+- `starts::BlkIdx`: a matrix specifying where each target block starts. Note that in
+  this case the cell index, i.e. the third row, specifies the cell index.
+
+# Notes
+The size of each block to ge gathered is worked out form the size of `target`.
+
+"""
+function _get_blocks!(src::AbstractArray{T, 3}, target::AbstractArray{T, 3}, starts::BlkIdx) where T
+    for i in 1:size(starts, 2)
+        @views target[:, :, i] = src[
+            starts[1, i]:starts[1, i] + size(target, 1) - 1,
+            starts[2, i]:starts[2, i] + size(target, 2) - 1,
+            starts[3, i]]
+    end
+end
+
+# The `_set_blocks!` methods perform the inverted operation of their `_get_blocks!`
+# counterparts as they place data **into** the Hamiltonian or overlap matrix. 
+
+"""
+    _set_blocks!(src, target, starts)
+
+Scatter blocks from the `src` matrix into the `target`. This method is to be used when
+assigning data to two-dimensional, single k-point, matrices. 
+
+# Arguments
+- `src::Matrix`: matrix from which data is to be drawn.
+- `target::Array`: array in which data should be stored.
+- `starts::BlkIdx`: a matrix specifying where each target block starts.
+
+# Notes
+The size of each block to ge gathered is worked out form the size of `target`.
+
+"""
+function _set_blocks!(src::AbstractArray{T, 3}, target::Matrix{T}, starts::BlkIdx) where T
+    for i in 1:size(starts, 2)
+        @views target[
+            starts[1, i]:starts[1, i] + size(src, 1) - 1,
+            starts[2, i]:starts[2, i] + size(src, 2) - 1,
+            ] = src[:, :, i]
+    end
+end
+
+"""
+    _set_blocks!(src, target, starts)
+
+Scatter blocks from the `src` matrix into the `target`. This method is to be used when
+assigning data to three-dimensional, real-space, matrices.
+
+# Arguments
+- `src::Matrix`: matrix from which data is to be drawn.
+- `target::Array`: array in which data should be stored.
+- `starts::BlkIdx`: a matrix specifying where each target block starts. Note that in
+  this case the cell index, i.e. the third row, specifies the cell index.
+
+# Notes
+The size of each block to ge gathered is worked out form the size of `target`.
+
+"""
+function _set_blocks!(src::AbstractArray{T, 3}, target::AbstractArray{T, 3}, starts::BlkIdx) where T
+    for i in 1:size(starts, 2)
+        @views target[
+            starts[1, i]:starts[1, i] + size(src, 1) - 1,
+            starts[2, i]:starts[2, i] + size(src, 2) - 1,
+            starts[3, i]
+            ] = src[:, :, i]
+    end
+end
+
+
+
+
+"""
+    get_sub_blocks(matrix, blk_idxs, s_i, s_j, atoms, basis_def)
+
+Collect sub-blocks of a given type from select atom-blocks in a provided matrix.
+
+This method will collect, from `matrix`, the `s_i`-`s_j` sub-block of each atom-block
+listed in `blk_idxs`. It is assumed that all atom-blocks are between identical pairs
+of species.
+
+# Arguments
+- `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
+  or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
+- `blk_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
+- `s_i::Int`: first shell
+- `s_j::Int`: second shell
+- `atoms::Atoms`: target system's `JuLIP.Atoms` objects
+- `basis_def:BasisDef`: corresponding basis set definition object (`BasisDef`)
+
+# Returns
+- `sub_blocks`: an array containing the collected sub-blocks.
+
+# Notes
+If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
+the origin cell is first.
+"""
+function get_sub_blocks(matrix::AbstractArray{T}, blk_idxs::BlkIdx, s_i, s_j, atoms::Atoms, basis_def) where T
+    z_1, z_2 = atoms.Z[blk_idxs[1:2, 1]]
+
+    # Identify where each target block starts (first column and row)
+    starts = _blk_starts(blk_idxs, atoms, basis_def)
+
+    # Shift `starts` so it points to the start of the **sub-blocks** rather than the block
+    starts[1:2, :] .+= _sblk_starts(z_1, z_2, s_i, s_j, basis_def) .- 1
+
+    data = Array{T, 3}(  # Array in which the resulting sub-blocks are to be collected
+        undef, 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1, size(blk_idxs, 2))
+    
+    # Carry out the assignment operation.
+    _get_blocks!(matrix, data, starts)
+    
+    return data
+end
+
+
+"""
+    set_sub_blocks(matrix, values, blk_idxs, s_i, s_j, atoms, basis_def)
+
+Place sub-block data from `values` representing the interaction between shells `s_i` &
+`s_j` into the matrix at the atom-blocks listed in `blk_idxs`. This is this performs
+the inverse operation to `set_sub_blocks`.
+
+# Arguments
+- `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
+  or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
+- `values::Array`: sub-block values.
+- `blk_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
+- `s_i::Int`: first shell
+- `s_j::Int`: second shell
+- `atoms::Atoms`: target system's `JuLIP.Atoms` objects
+- `basis_def:BasisDef`: corresponding basis set definition object (`BasisDef`)
+
+# Notes
+If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
+the origin cell is first.
+"""
+function set_sub_blocks!(matrix::AbstractArray, values, blk_idxs::BlkIdx, s_i, s_j, atoms::Atoms, basis_def)
+    
+    if size(values, 3) != size(blk_idxs, 2)
+        throw(DimensionMismatch(
+            "The last dimensions of `values` & `blk_idxs` must be of the same length."))
+    end
+    
+    z_1, z_2 = atoms.Z[blk_idxs[1:2, 1]]
+
+    # Identify where each target block starts (first column and row)
+    starts = _blk_starts(blk_idxs, atoms, basis_def)
+
+    # Shift `starts` so it points to the start of the **sub-blocks** rather than the block
+    starts[1:2, :] .+= _sblk_starts(z_1, z_2, s_i, s_j, basis_def) .- 1
+
+    # Carry out the scatter operation.
+    _set_blocks!(values, matrix, starts)
+end
+
+
+"""
+    get_blocks(matrix, blk_idxs, atoms, basis_def)
+
+Collect, from `matrix`, the blocks listed in `blk_idxs`.
+
+# Arguments
+- `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
+  or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
+- `blk_idxs::BlkIdx`: the atomic-blocks to gathered.
+- `atoms::Atoms`: target system's `JuLIP.Atoms` objects
+- `basis_def:BasisDef`: corresponding basis set definition object (`BasisDef`)
+
+# Returns
+- `sub_blocks`: an array containing the collected sub-blocks.
+
+# Notes
+If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
+the origin cell is first.
+"""
+function get_blocks(matrix::AbstractArray{T}, blk_idxs::BlkIdx, atoms::Atoms, basis_def) where T
+    z_1, z_2 = atoms.Z[blk_idxs[1:2, 1]]
+
+    # Identify where each target block starts (first column and row)
+    starts = _blk_starts(blk_idxs, atoms, basis_def)
+
+    data = Array{T, 3}(  # Array in which the resulting blocks are to be collected
+        undef, sum(2basis_def[z_1].+ 1), sum(2basis_def[z_2].+ 1), size(blk_idxs, 2))
+    
+    # Carry out the assignment operation.
+    _get_blocks!(matrix, data, starts)
+    
+    return data
+end
+
+
+"""
+    set_sub_blocks(matrix, values, blk_idxs, s_i, s_j, atoms, basis_def)
+
+Place atom-block data from `values` into the matrix at the atom-blocks listed in `blk_idxs`.
+This is this performs the inverse operation to `set_blocks`.
+
+# Arguments
+- `matrix::Array`: matrix from which to draw. This may be in either the 3D real-space N×N×C form
+  or the single k-point N×N form; where N & C are the N∘ of orbitals & images respectively.
+- `values::Array`: sub-block values.
+- `blk_idxs::BlkIdx`: atomic-blocks from which sub-blocks are to be gathered.
+- `s_i::Int`: first shell
+- `s_j::Int`: second shell
+- `atoms::Atoms`: target system's `JuLIP.Atoms` objects
+- `basis_def:BasisDef`: corresponding basis set definition object (`BasisDef`)
+
+# Notes
+If `matrix` is supplied in its 3D real-space form then it is imperative to ensure that
+the origin cell is first.
+"""
+function set_blocks!(matrix::AbstractArray, values, blk_idxs::BlkIdx, atoms::Atoms, basis_def)
+
+    if size(values, 3) != size(blk_idxs, 2)
+        throw(DimensionMismatch(
+            "The last dimensions of `values` & `blk_idxs` must be of the same length."))
+    end
+
+    # Identify where each target block starts (first column and row)
+    starts = _blk_starts(blk_idxs, atoms, basis_def)
+
+    # Carry out the scatter operation.
+    _set_blocks!(values, matrix, starts)
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
 @testset "ACEhamiltonians.jl" begin
     @testset "Unit Tests" begin
         include("unit_tests/test_parameters.jl")
+        include("unit_tests/test_data.jl")
     end
 
     @testset "Regression Tests" begin

--- a/test/unit_tests/test_data.jl
+++ b/test/unit_tests/test_data.jl
@@ -2,41 +2,41 @@ using ACEhamiltonians, Test, Random
 using JuLIP: Atoms
 
 
-using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks!, _set_blocks!
+using ACEhamiltonians.MatrixManipulation: _block_starts, _sub_block_starts, _get_blocks!, _set_blocks!
 
 
 @testset "Matrix Manipulation" begin
     @testset "Constructors" begin
-        @testset "atomic_blk_idxs" begin
+        @testset "atomic_block_idxs" begin
             for z_s in ([1, 6, 1, 6], Atoms(;Z=[1, 6, 1, 6]))
-                @test atomic_blk_idxs(1, 1, z_s) == [1 1 3 3; 1 3 1 3]
-                @test atomic_blk_idxs(1, 6, z_s) == [1 1 3 3; 2 4 2 4]
-                @test atomic_blk_idxs(6, 1, z_s) == [2 2 4 4; 1 3 1 3]
-                @test atomic_blk_idxs(6, 6, z_s) == [2 2 4 4; 2 4 2 4]
+                @test atomic_block_idxs(1, 1, z_s) == [1 1 3 3; 1 3 1 3]
+                @test atomic_block_idxs(1, 6, z_s) == [1 1 3 3; 2 4 2 4]
+                @test atomic_block_idxs(6, 1, z_s) == [2 2 4 4; 1 3 1 3]
+                @test atomic_block_idxs(6, 6, z_s) == [2 2 4 4; 2 4 2 4]
 
-                @test atomic_blk_idxs(1, 6, z_s; order_invariant=true) == [1 1 3 3 2 2 4 4; 2 4 2 4 1 3 1 3]
-                @test atomic_blk_idxs(6, 1, z_s; order_invariant=true) == [2 2 4 4 1 1 3 3; 1 3 1 3 2 4 2 4]
+                @test atomic_block_idxs(1, 6, z_s; order_invariant=true) == [1 1 3 3 2 2 4 4; 2 4 2 4 1 3 1 3]
+                @test atomic_block_idxs(6, 1, z_s; order_invariant=true) == [2 2 4 4 1 1 3 3; 1 3 1 3 2 4 2 4]
             end
         end
 
-        @testset "repeat_atomic_blk_idxs" begin
-            blk_idxs_a = [
+        @testset "repeat_atomic_block_idxs" begin
+            block_idxs_a = [
                 1 2 3
                 4 5 6]
-            blk_idxs_b = [
+            block_idxs_b = [
                 1 2 3 1 2 3 1 2 3
                 4 5 6 4 5 6 4 5 6
                 1 1 1 2 2 2 3 3 3]
-            @test repeat_atomic_blk_idxs(blk_idxs_a, 3) == blk_idxs_b
+            @test repeat_atomic_block_idxs(block_idxs_a, 3) == block_idxs_b
 
-            @test_throws AssertionError repeat_atomic_blk_idxs(blk_idxs_b, 3)
+            @test_throws AssertionError repeat_atomic_block_idxs(block_idxs_b, 3)
     
         end
     end
 
     @testset "Ancillary" begin
 
-        @testset "_blk_starts" begin
+        @testset "_block_starts" begin
             basis_def = Dict(1=>[0], 6=>[0,1], 7=>[0, 0, 1, 1, 2])
             atoms = Atoms(;Z=[1, 6, 7, 6])
             starts = [1, 2, 6, 19]
@@ -46,23 +46,23 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                 [1 1; 2 4], [2 4; 1 1], [1; 3;;], [3; 1;;], [2 2 4 4; 2 4 2 4],
                 [2 4; 3 3], [3 3; 2 4]]
 
-            for sblks in sub_blocks
-                @test _blk_starts(sblks, atoms, basis_def) == starts[sblks]
+            for sub_blocks in sub_blocks
+                @test _block_starts(sub_blocks, atoms, basis_def) == starts[sub_blocks]
             end
 
             # Ensure that cell indices are preserved and their presence does not effect the results
-            @test _blk_starts([2 4; 3 3; 11 22], atoms, basis_def)[1:2, :] == _blk_starts([2 4; 3 3], atoms, basis_def)
-            @test _blk_starts([2 4; 3 3; 11 12], atoms, basis_def)[3, :] == [11, 12]
+            @test _block_starts([2 4; 3 3; 11 22], atoms, basis_def)[1:2, :] == _block_starts([2 4; 3 3], atoms, basis_def)
+            @test _block_starts([2 4; 3 3; 11 12], atoms, basis_def)[3, :] == [11, 12]
             
         end
 
-        @testset "_sblk_starts" begin
+        @testset "_sub_block_starts" begin
             basis_def = Dict(1=>[0], 6=>[0, 1], 7=>[0, 0, 1, 1, 2])
             starts = Dict(1=>[1], 6=>[1, 2], 7=>[1, 2, 3, 6, 9])
             z_s = collect(keys(basis_def))
             for z_1=z_s, z_2=z_s
                 for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
-                    @test _sblk_starts(z_1, z_2, s_i, s_j, basis_def) == [starts[z_1][s_i], starts[z_2][s_j]]
+                    @test _sub_block_starts(z_1, z_2, s_i, s_j, basis_def) == [starts[z_1][s_i], starts[z_2][s_j]]
                 end
             end
         end
@@ -164,8 +164,8 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
 
             mat_size = 1000
             n_cells = 10
-            max_blk_size = 10
-            max_idx = mat_size - max_blk_size - 1
+            max_block_size = 10
+            max_idx = mat_size - max_block_size - 1
             n_samples = 10
             n_blocks = 12
 
@@ -174,7 +174,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                 @testset "2D" begin
                     src = rand(mat_size, mat_size)
                     for _=1:n_samples
-                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        n, m = rand(1:max_block_size), rand(1:max_block_size)
                         starts = rand(1:max_idx, 2, n_blocks)
                         
                         ref = Array{valtype(src), 3}(undef, n, m, n_blocks)
@@ -192,7 +192,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                 @testset "3D" begin
                     src = rand(mat_size, mat_size, n_cells)
                     for _=1:n_samples
-                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        n, m = rand(1:max_block_size), rand(1:max_block_size)
                         starts = vcat(rand(1:max_idx, 2, n_blocks), rand(1:n_cells, 1, n_blocks))
                         
                         ref = Array{valtype(src), 3}(undef, n, m, n_blocks)
@@ -217,7 +217,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     target = rand(mat_size, mat_size)
 
                     for _=1:n_samples
-                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        n, m = rand(1:max_block_size), rand(1:max_block_size)
                         
                         # Starts must be generated so that they don't cause blocks to overlap 
                         starts = Matrix{Int}(undef, 2, n_blocks)
@@ -229,7 +229,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                             safe_max = 0
                             while any(abs.(starts[1,1:c] .- i) .< n)
                                 safe_max += 1
-                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_block_size"
                                 i = rand(1:max_idx)
                             end
 
@@ -237,7 +237,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                             safe_max = 0
                             while any(abs.(starts[2,1:c] .- j) .< m)
                                 safe_max += 1
-                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_block_size"
                                 j = rand(1:max_idx)
                             end
 
@@ -263,7 +263,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     target = rand(mat_size, mat_size, n_cells)
 
                     for _=1:n_samples
-                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        n, m = rand(1:max_block_size), rand(1:max_block_size)
                         
                         # Starts must be generated so that they don't cause blocks to overlap 
                         starts = Matrix{Int}(undef, 3, n_blocks)
@@ -275,7 +275,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                             safe_max = 0
                             while any(abs.(starts[1,1:c] .- i) .< n)
                                 safe_max += 1
-                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_block_size"
                                 i = rand(1:max_idx)
                             end
 
@@ -283,7 +283,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                             safe_max = 0
                             while any(abs.(starts[2,1:c] .- j) .< m)
                                 safe_max += 1
-                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_block_size"
                                 j = rand(1:max_idx)
                             end
 
@@ -330,11 +330,11 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                         for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
                             rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
 
-                            blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
-                            sub_blocks = get_sub_blocks(matrix_a, blk_idxs, s_i, s_j, atoms, basis_def)
+                            block_idxs = atomic_block_idxs(z_1, z_2, z_s)
+                            sub_blocks = get_sub_blocks(matrix_a, block_idxs, s_i, s_j, atoms, basis_def)
                             sub_blocks_ref = zeros(size(sub_blocks)...)
-                            for i=1:size(blk_idxs, 2)
-                                r, c = block_starts[blk_idxs[:, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                            for i=1:size(block_idxs, 2)
+                                r, c = block_starts[block_idxs[:, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
                                 sub_blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
                             end
 
@@ -349,13 +349,13 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                         for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
                             rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
 
-                            blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
-                            sub_blocks = get_sub_blocks(matrix_b, blk_idxs, s_i, s_j, atoms, basis_def)
+                            block_idxs = repeat_atomic_block_idxs(atomic_block_idxs(z_1, z_2, z_s), 10)
+                            sub_blocks = get_sub_blocks(matrix_b, block_idxs, s_i, s_j, atoms, basis_def)
                             sub_blocks_ref = zeros(size(sub_blocks)...)
-                            for i=1:size(blk_idxs, 2)
-                                r, c = block_starts[blk_idxs[1:2, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                            for i=1:size(block_idxs, 2)
+                                r, c = block_starts[block_idxs[1:2, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
                                 
-                                sub_blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                                sub_blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, block_idxs[3, i]]
                             end
 
                             @test sub_blocks == sub_blocks_ref
@@ -372,11 +372,11 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     for z_1=species, z_2=species
                         rs, cs = atom_sizes[z_1], atom_sizes[z_2]
 
-                        blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
-                        blocks = get_blocks(matrix_a, blk_idxs, atoms, basis_def)
+                        block_idxs = atomic_block_idxs(z_1, z_2, z_s)
+                        blocks = get_blocks(matrix_a, block_idxs, atoms, basis_def)
                         blocks_ref = zeros(size(blocks)...)
-                        for i=1:size(blk_idxs, 2)
-                            r, c = block_starts[blk_idxs[:, i]]
+                        for i=1:size(block_idxs, 2)
+                            r, c = block_starts[block_idxs[:, i]]
                             
                             blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
                         end
@@ -389,13 +389,13 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     for z_1=species, z_2=species
                         rs, cs = atom_sizes[z_1], atom_sizes[z_2]
 
-                        blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
-                        blocks = get_blocks(matrix_b, blk_idxs, atoms, basis_def)
+                        block_idxs = repeat_atomic_block_idxs(atomic_block_idxs(z_1, z_2, z_s), 10)
+                        blocks = get_blocks(matrix_b, block_idxs, atoms, basis_def)
                         blocks_ref = zeros(size(blocks)...)
-                        for i=1:size(blk_idxs, 2)
-                            r, c = block_starts[blk_idxs[1:2, i]]
+                        for i=1:size(block_idxs, 2)
+                            r, c = block_starts[block_idxs[1:2, i]]
                             
-                            blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                            blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, block_idxs[3, i]]
                         end
 
                         @test blocks == blocks_ref
@@ -411,13 +411,13 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                         for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
                             rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
 
-                            blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
-                            sub_blocks = rand(rs, cs, size(blk_idxs, 2))
-                            set_sub_blocks!(matrix_a, sub_blocks, blk_idxs, s_i, s_j, atoms, basis_def)
+                            block_idxs = atomic_block_idxs(z_1, z_2, z_s)
+                            sub_blocks = rand(rs, cs, size(block_idxs, 2))
+                            set_sub_blocks!(matrix_a, sub_blocks, block_idxs, s_i, s_j, atoms, basis_def)
 
                             sub_blocks_ref = zeros(size(sub_blocks)...)
-                            for i=1:size(blk_idxs, 2)
-                                r, c = block_starts[blk_idxs[:, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                            for i=1:size(block_idxs, 2)
+                                r, c = block_starts[block_idxs[:, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
                                 sub_blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
                             end
 
@@ -432,14 +432,14 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                         for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
                             rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
 
-                            blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
-                            sub_blocks = rand(rs, cs, size(blk_idxs, 2))
-                            set_sub_blocks!(matrix_b, sub_blocks, blk_idxs, s_i, s_j, atoms, basis_def)
+                            block_idxs = repeat_atomic_block_idxs(atomic_block_idxs(z_1, z_2, z_s), 10)
+                            sub_blocks = rand(rs, cs, size(block_idxs, 2))
+                            set_sub_blocks!(matrix_b, sub_blocks, block_idxs, s_i, s_j, atoms, basis_def)
 
                             sub_blocks_ref = zeros(size(sub_blocks)...)
-                            for i=1:size(blk_idxs, 2)
-                                r, c = block_starts[blk_idxs[1:2, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
-                                sub_blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                            for i=1:size(block_idxs, 2)
+                                r, c = block_starts[block_idxs[1:2, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                                sub_blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, block_idxs[3, i]]
                             end
 
                             @test sub_blocks == sub_blocks_ref
@@ -455,13 +455,13 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     for z_1=species, z_2=species
                         rs, cs = atom_sizes[z_1], atom_sizes[z_2]
 
-                        blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
-                        blocks = rand(rs, cs, size(blk_idxs, 2))
-                        set_blocks!(matrix_a, blocks, blk_idxs, atoms, basis_def)
+                        block_idxs = atomic_block_idxs(z_1, z_2, z_s)
+                        blocks = rand(rs, cs, size(block_idxs, 2))
+                        set_blocks!(matrix_a, blocks, block_idxs, atoms, basis_def)
 
                         blocks_ref = zeros(size(blocks)...)
-                        for i=1:size(blk_idxs, 2)
-                            r, c = block_starts[blk_idxs[1:2, i]]
+                        for i=1:size(block_idxs, 2)
+                            r, c = block_starts[block_idxs[1:2, i]]
                             blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
                         end
 
@@ -474,14 +474,14 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     for z_1=species, z_2=species
                         rs, cs = atom_sizes[z_1], atom_sizes[z_2]
 
-                        blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
-                        blocks = rand(rs, cs, size(blk_idxs, 2))
-                        set_blocks!(matrix_b, blocks, blk_idxs, atoms, basis_def)
+                        block_idxs = repeat_atomic_block_idxs(atomic_block_idxs(z_1, z_2, z_s), 10)
+                        blocks = rand(rs, cs, size(block_idxs, 2))
+                        set_blocks!(matrix_b, blocks, block_idxs, atoms, basis_def)
 
                         blocks_ref = zeros(size(blocks)...)
-                        for i=1:size(blk_idxs, 2)
-                            r, c = block_starts[blk_idxs[1:2, i]]
-                            blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                        for i=1:size(block_idxs, 2)
+                            r, c = block_starts[block_idxs[1:2, i]]
+                            blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, block_idxs[3, i]]
                         end
 
                         @test blocks == blocks_ref

--- a/test/unit_tests/test_data.jl
+++ b/test/unit_tests/test_data.jl
@@ -1,0 +1,499 @@
+using ACEhamiltonians, Test, Random
+using JuLIP: Atoms
+
+
+using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks!, _set_blocks!
+
+
+@testset "Matrix Manipulation" begin
+    @testset "Constructors" begin
+        @testset "atomic_blk_idxs" begin
+            for z_s in ([1, 6, 1, 6], Atoms(;Z=[1, 6, 1, 6]))
+                @test atomic_blk_idxs(1, 1, z_s) == [1 1 3 3; 1 3 1 3]
+                @test atomic_blk_idxs(1, 6, z_s) == [1 1 3 3; 2 4 2 4]
+                @test atomic_blk_idxs(6, 1, z_s) == [2 2 4 4; 1 3 1 3]
+                @test atomic_blk_idxs(6, 6, z_s) == [2 2 4 4; 2 4 2 4]
+
+                @test atomic_blk_idxs(1, 6, z_s; order_invariant=true) == [1 1 3 3 2 2 4 4; 2 4 2 4 1 3 1 3]
+                @test atomic_blk_idxs(6, 1, z_s; order_invariant=true) == [2 2 4 4 1 1 3 3; 1 3 1 3 2 4 2 4]
+            end
+        end
+
+        @testset "repeat_atomic_blk_idxs" begin
+            blk_idxs_a = [
+                1 2 3
+                4 5 6]
+            blk_idxs_b = [
+                1 2 3 1 2 3 1 2 3
+                4 5 6 4 5 6 4 5 6
+                1 1 1 2 2 2 3 3 3]
+            @test repeat_atomic_blk_idxs(blk_idxs_a, 3) == blk_idxs_b
+
+            @test_throws AssertionError repeat_atomic_blk_idxs(blk_idxs_b, 3)
+    
+        end
+    end
+
+    @testset "Ancillary" begin
+
+        @testset "_blk_starts" begin
+            basis_def = Dict(1=>[0], 6=>[0,1], 7=>[0, 0, 1, 1, 2])
+            atoms = Atoms(;Z=[1, 6, 7, 6])
+            starts = [1, 2, 6, 19]
+
+            # Check general functionality
+            sub_blocks = [
+                [1 1; 2 4], [2 4; 1 1], [1; 3;;], [3; 1;;], [2 2 4 4; 2 4 2 4],
+                [2 4; 3 3], [3 3; 2 4]]
+
+            for sblks in sub_blocks
+                @test _blk_starts(sblks, atoms, basis_def) == starts[sblks]
+            end
+
+            # Ensure that cell indices are preserved and their presence does not effect the results
+            @test _blk_starts([2 4; 3 3; 11 22], atoms, basis_def)[1:2, :] == _blk_starts([2 4; 3 3], atoms, basis_def)
+            @test _blk_starts([2 4; 3 3; 11 12], atoms, basis_def)[3, :] == [11, 12]
+            
+        end
+
+        @testset "_sblk_starts" begin
+            basis_def = Dict(1=>[0], 6=>[0, 1], 7=>[0, 0, 1, 1, 2])
+            starts = Dict(1=>[1], 6=>[1, 2], 7=>[1, 2, 3, 6, 9])
+            z_s = collect(keys(basis_def))
+            for z_1=z_s, z_2=z_s
+                for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
+                    @test _sblk_starts(z_1, z_2, s_i, s_j, basis_def) == [starts[z_1][s_i], starts[z_2][s_j]]
+                end
+            end
+        end
+    end
+
+    @testset "Filters" begin
+        @testset "filter_on_site_idxs" begin
+            # Without cell index row
+            @test filter_on_site_idxs([
+                1 1 1 2 2 2 3 3 3;
+                1 2 3 1 2 3 1 2 3
+                ]) == [
+                1 2 3;
+                1 2 3
+                 ]
+
+            # With cell index row
+            @test filter_on_site_idxs([
+                1 1 2 2 1 1 2 2;
+                1 2 1 2 1 2 1 2;
+                1 1 1 1 2 2 2 2
+                ]) == [
+                1 2;
+                1 2;
+                1 1
+                ]
+            
+        end
+        
+        @testset "filter_off_site_idxs" begin
+            # Without cell index row
+            @test filter_off_site_idxs([
+                1 1 1 2 2 2 3 3 3;
+                1 2 3 1 2 3 1 2 3
+                ]) == [
+                1 1 2 2 3 3;
+                2 3 1 3 1 2
+                ]
+
+            # With cell index row
+            @test filter_off_site_idxs([
+                1 1 2 2 1 1 2 2;
+                1 2 1 2 1 2 1 2;
+                1 1 1 1 2 2 2 2
+                ]) == [
+                1 2 1 1 2 2;
+                2 1 1 2 1 2;
+                1 1 2 2 2 2
+                ]
+        end
+        @testset "filter_upper_idxs" begin
+            # Without cell index row
+            @test filter_upper_idxs([
+                1 1 1 2 2 2 3 3 3;
+                1 2 3 1 2 3 1 2 3
+                ]) == [
+                1 1 1 2 2 3;
+                1 2 3 2 3 3
+                ]
+
+            # With cell index row
+            @test filter_upper_idxs([
+                1 1 1 2 2 2 3 3 3;
+                1 2 3 1 2 3 1 2 3;
+                1 2 3 4 5 6 7 8 9
+                ]) == [
+                1 1 1 2 2 3;
+                1 2 3 2 3 3
+                1 2 3 5 6 9
+                ]
+        end
+
+        @testset "filter_lower_idxs" begin
+            # Without cell index row
+            @test filter_lower_idxs([
+                1 1 1 2 2 2 3 3 3;
+                1 2 3 1 2 3 1 2 3
+                ]) == [
+                1 2 2 3 3 3;
+                1 1 2 1 2 3
+                ]
+
+            # With cell index row
+            @test filter_lower_idxs([
+                1 1 1 2 2 2 3 3 3;
+                1 2 3 1 2 3 1 2 3;
+                1 2 3 4 5 6 7 8 9
+                ]) == [
+                1 2 2 3 3 3;
+                1 1 2 1 2 3
+                1 4 5 7 8 9
+                ]
+        end
+    end
+    @testset "Data Assignment" begin
+
+        @testset "Private" begin
+
+
+            mat_size = 1000
+            n_cells = 10
+            max_blk_size = 10
+            max_idx = mat_size - max_blk_size - 1
+            n_samples = 10
+            n_blocks = 12
+
+            # Gathering data from a matrix
+            @testset "_get_blocks!" begin
+                @testset "2D" begin
+                    src = rand(mat_size, mat_size)
+                    for _=1:n_samples
+                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        starts = rand(1:max_idx, 2, n_blocks)
+                        
+                        ref = Array{valtype(src), 3}(undef, n, m, n_blocks)
+                        for i=1:n_blocks
+                            ref[:, :, i] = src[starts[1, i]:starts[1, i] + n - 1, starts[2, i]:starts[2, i] + m - 1]
+                        end
+
+                        target = Array{valtype(src), 3}(undef, n, m, n_blocks)
+                        _get_blocks!(src, target, starts)
+
+                        @test target == ref
+                    end
+                end
+
+                @testset "3D" begin
+                    src = rand(mat_size, mat_size, n_cells)
+                    for _=1:n_samples
+                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        starts = vcat(rand(1:max_idx, 2, n_blocks), rand(1:n_cells, 1, n_blocks))
+                        
+                        ref = Array{valtype(src), 3}(undef, n, m, n_blocks)
+                        for i=1:n_blocks
+                            ref[:, :, i] = src[starts[1, i]:starts[1, i] + n - 1, starts[2, i]:starts[2, i] + m - 1, starts[3, i]]
+                        end
+
+                        target = Array{valtype(src), 3}(undef, n, m, n_blocks)
+                        _get_blocks!(src, target, starts)
+
+                        @test target == ref
+                    end
+                end
+            end
+
+            # Placing data in the matrix
+            @testset "_set_blocks!" begin
+
+                # There is an issue here where the same block might get written to twice.
+                @testset "2D" begin
+
+                    target = rand(mat_size, mat_size)
+
+                    for _=1:n_samples
+                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        
+                        # Starts must be generated so that they do cause blocks to overlap 
+                        starts = Matrix{Int}(undef, 2, n_blocks)
+                        
+                        for c=1:n_blocks
+                            
+                            i, j = rand(1:max_idx, 2)
+    
+                            safe_max = 0
+                            while any(abs.(starts[1,1:c] .- i) .< n)
+                                safe_max += 1
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                i = rand(1:max_idx)
+                            end
+
+                            
+                            safe_max = 0
+                            while any(abs.(starts[2,1:c] .- j) .< m)
+                                safe_max += 1
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                j = rand(1:max_idx)
+                            end
+
+                            starts[1, c] = i
+                            starts[2, c] = j 
+                            
+                        end
+                        
+                        src = rand(valtype(target), n, m, n_blocks)
+                        _set_blocks!(src, target, starts)
+
+                        ref = Array{valtype(src), 3}(undef, n, m, n_blocks)
+                        for i=1:n_blocks
+                            ref[:, :, i] = target[starts[1, i]:starts[1, i] + n - 1, starts[2, i]:starts[2, i] + m - 1]
+                        end
+
+                        @test src == ref
+                    end
+                end
+
+                @testset "3D" begin
+
+                    target = rand(mat_size, mat_size, n_cells)
+
+                    for _=1:n_samples
+                        n, m = rand(1:max_blk_size), rand(1:max_blk_size)
+                        
+                        # Starts must be generated so that they do cause blocks to overlap 
+                        starts = Matrix{Int}(undef, 3, n_blocks)
+                        
+                        for c=1:n_blocks
+                            
+                            i, j = rand(1:max_idx, 2)
+    
+                            safe_max = 0
+                            while any(abs.(starts[1,1:c] .- i) .< n)
+                                safe_max += 1
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                i = rand(1:max_idx)
+                            end
+
+                            
+                            safe_max = 0
+                            while any(abs.(starts[2,1:c] .- j) .< m)
+                                safe_max += 1
+                                @assert safe_max < 1000 "Increase mat_size or decrease max_blk_size"
+                                j = rand(1:max_idx)
+                            end
+
+                            starts[1, c] = i
+                            starts[2, c] = j
+                            starts[3, c] = rand(1:n_cells)
+                            
+                        end
+                        
+                        src = rand(valtype(target), n, m, n_blocks)
+                        _set_blocks!(src, target, starts)
+
+                        ref = Array{valtype(src), 3}(undef, n, m, n_blocks)
+                        for i=1:n_blocks
+                            ref[:, :, i] = target[starts[1, i]:starts[1, i] + n - 1, starts[2, i]:starts[2, i] + m - 1, starts[3, i]]
+                        end
+
+                        @test src == ref
+                    end
+                end
+            end
+        end
+
+        @testset "Public" begin
+            # Again there is a fair bit of repetition going on here.
+
+            basis_def = Dict(1=>[0], 6=>[0,1], 7=>[0, 0, 1, 1, 2])
+            starts = Dict(1=>[1], 6=>[1, 2], 7=>[1, 2, 3, 6, 9])
+            atom_sizes = Dict(k=>sum(2v .+ 1) for (k, v) in basis_def)
+
+            atoms = Atoms(;Z=[1, 6, 1, 7, 7, 6])
+            block_starts = [1, 2, 6, 7, 20, 33]
+
+            species = convert(Vector{Int}, collect(keys(basis_def)))
+            z_s = convert(Vector{Int}, atoms.Z)
+
+            matrix_a = rand(36, 36)
+            matrix_b = rand(36, 36, 10) 
+
+            @testset "get_sub_blocks" begin
+
+                @testset "2D" begin
+                    for z_1=species, z_2=species
+                        for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
+                            rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
+
+                            blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
+                            sub_blocks = get_sub_blocks(matrix_a, blk_idxs, s_i, s_j, atoms, basis_def)
+                            sub_blocks_ref = zeros(size(sub_blocks)...)
+                            for i=1:size(blk_idxs, 2)
+                                r, c = block_starts[blk_idxs[:, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                                sub_blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
+                            end
+
+                            @test sub_blocks == sub_blocks_ref
+                            
+                        end
+                    end
+                end
+
+                @testset "3D" begin
+                    for z_1=species, z_2=species
+                        for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
+                            rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
+
+                            blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
+                            sub_blocks = get_sub_blocks(matrix_b, blk_idxs, s_i, s_j, atoms, basis_def)
+                            sub_blocks_ref = zeros(size(sub_blocks)...)
+                            for i=1:size(blk_idxs, 2)
+                                r, c = block_starts[blk_idxs[1:2, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                                
+                                sub_blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                            end
+
+                            @test sub_blocks == sub_blocks_ref
+                            
+                        end
+                    end
+                end
+
+            end
+
+            @testset "get_blocks" begin
+
+                @testset "2D" begin
+                    for z_1=species, z_2=species
+                        rs, cs = atom_sizes[z_1], atom_sizes[z_2]
+
+                        blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
+                        blocks = get_blocks(matrix_a, blk_idxs, atoms, basis_def)
+                        blocks_ref = zeros(size(blocks)...)
+                        for i=1:size(blk_idxs, 2)
+                            r, c = block_starts[blk_idxs[:, i]]
+                            
+                            blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
+                        end
+
+                        @test blocks == blocks_ref
+                    end
+                end
+
+                @testset "3D" begin
+                    for z_1=species, z_2=species
+                        rs, cs = atom_sizes[z_1], atom_sizes[z_2]
+
+                        blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
+                        blocks = get_blocks(matrix_b, blk_idxs, atoms, basis_def)
+                        blocks_ref = zeros(size(blocks)...)
+                        for i=1:size(blk_idxs, 2)
+                            r, c = block_starts[blk_idxs[1:2, i]]
+                            
+                            blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                        end
+
+                        @test blocks == blocks_ref
+                    end
+                end
+                
+            end
+
+            @testset "set_sub_blocks!" begin
+
+                @testset "2D" begin
+                    for z_1=species, z_2=species
+                        for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
+                            rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
+
+                            blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
+                            sub_blocks = rand(rs, cs, size(blk_idxs, 2))
+                            set_sub_blocks!(matrix_a, sub_blocks, blk_idxs, s_i, s_j, atoms, basis_def)
+
+                            sub_blocks_ref = zeros(size(sub_blocks)...)
+                            for i=1:size(blk_idxs, 2)
+                                r, c = block_starts[blk_idxs[:, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                                sub_blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
+                            end
+
+                            @test sub_blocks == sub_blocks_ref
+                            
+                        end
+                    end
+                end
+
+                @testset "3D" begin
+                    for z_1=species, z_2=species
+                        for s_i=1:length(basis_def[z_1]), s_j=length(basis_def[z_2])
+                            rs, cs = 2basis_def[z_1][s_i] + 1, 2basis_def[z_2][s_j] + 1
+
+                            blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
+                            sub_blocks = rand(rs, cs, size(blk_idxs, 2))
+                            set_sub_blocks!(matrix_b, sub_blocks, blk_idxs, s_i, s_j, atoms, basis_def)
+
+                            sub_blocks_ref = zeros(size(sub_blocks)...)
+                            for i=1:size(blk_idxs, 2)
+                                r, c = block_starts[blk_idxs[1:2, i]] + [starts[z_1][s_i],  starts[z_2][s_j]] .- 1
+                                sub_blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                            end
+
+                            @test sub_blocks == sub_blocks_ref
+                            
+                        end
+                    end
+                end                
+            end
+
+            @testset "set_blocks!" begin
+
+                @testset "2D" begin
+                    for z_1=species, z_2=species
+                        rs, cs = atom_sizes[z_1], atom_sizes[z_2]
+
+                        blk_idxs = atomic_blk_idxs(z_1, z_2, z_s)
+                        blocks = rand(rs, cs, size(blk_idxs, 2))
+                        set_blocks!(matrix_a, blocks, blk_idxs, atoms, basis_def)
+
+                        blocks_ref = zeros(size(blocks)...)
+                        for i=1:size(blk_idxs, 2)
+                            r, c = block_starts[blk_idxs[1:2, i]]
+                            blocks_ref[:, :, i] = matrix_a[r:r+rs-1, c:c+cs-1]
+                        end
+
+                        @test blocks == blocks_ref
+
+                    end
+                end
+
+                @testset "3D" begin
+                    for z_1=species, z_2=species
+                        rs, cs = atom_sizes[z_1], atom_sizes[z_2]
+
+                        blk_idxs = repeat_atomic_blk_idxs(atomic_blk_idxs(z_1, z_2, z_s), 10)
+                        blocks = rand(rs, cs, size(blk_idxs, 2))
+                        set_blocks!(matrix_b, blocks, blk_idxs, atoms, basis_def)
+
+                        blocks_ref = zeros(size(blocks)...)
+                        for i=1:size(blk_idxs, 2)
+                            r, c = block_starts[blk_idxs[1:2, i]]
+                            blocks_ref[:, :, i] = matrix_b[r:r+rs-1, c:c+cs-1, blk_idxs[3, i]]
+                        end
+
+                        @test blocks == blocks_ref
+                        
+                    
+                    end
+                end
+
+            end
+        end
+
+    end
+    
+end
+

--- a/test/unit_tests/test_data.jl
+++ b/test/unit_tests/test_data.jl
@@ -219,7 +219,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     for _=1:n_samples
                         n, m = rand(1:max_blk_size), rand(1:max_blk_size)
                         
-                        # Starts must be generated so that they do cause blocks to overlap 
+                        # Starts must be generated so that they don't cause blocks to overlap 
                         starts = Matrix{Int}(undef, 2, n_blocks)
                         
                         for c=1:n_blocks
@@ -265,7 +265,7 @@ using ACEhamiltonians.MatrixManipulation: _blk_starts, _sblk_starts, _get_blocks
                     for _=1:n_samples
                         n, m = rand(1:max_blk_size), rand(1:max_blk_size)
                         
-                        # Starts must be generated so that they do cause blocks to overlap 
+                        # Starts must be generated so that they don't cause blocks to overlap 
                         starts = Matrix{Int}(undef, 3, n_blocks)
                         
                         for c=1:n_blocks


### PR DESCRIPTION
This pull request introduces some general matrix manipulation subroutines. These methods are intended to facilitate the efficient gathering and scattering of data to and from square orbital matrices; e.g. Hamiltonian, overlap, etc. This supports both block and sub-block operations as well as a host of other ancillary functions intended to aid in the process of block and sub-block selection and refinement. This implements the first base components of the `data.jl` module file.