### PR TITLE
Enables species in the `Model` fitting level

### DIFF
--- a/docs/src/Getting_Started/Bases/Basis_Fitting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Fitting.md
@@ -19,7 +19,7 @@ end
 species = unique(atoms.Z)
 # Alternatively, one can use 
 # using JuLIP
-# species = [ keys(basis_definition)... ]
+# species = AtomicNumber.([ keys(basis_definition)... ])
 
 # Construct a pair of on and off-site bases
 on_site_basis = Basis(on_site_ace_basis(0, 1, 2, 4, 6.0; species = (try species catch nothing end)), (14, 3, 4))

--- a/docs/src/Getting_Started/Bases/Basis_Fitting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Fitting.md
@@ -8,16 +8,19 @@ database_path = "example_data.h5"
 # Name/path of/to the system to which fitting data should be drawn 
 target_system = "0224"
 
-# Construct a pair of on and off-site bases
-on_site_basis = Basis(on_site_ace_basis(0, 1, 2, 4, 6.0), (14, 3, 4))
-off_site_basis = Basis(off_site_ace_basis(1, 1, 1, 4, 8.0, 4.0), (14, 14, 6, 6))
-
-
 # Load the real-space Hamiltonian matrix, atoms object, cell translation vectors, and basis set definition
 H, atoms, images, basis_definition = h5open(database_path) do database
     target = database[target_system]
     load_hamiltonian(target), load_atoms(target; recentre=true), load_cell_translations(target), load_basis_set_definition(target)
 end
+
+# Get the species of the system - it can be done in several ways and here just comes one
+# This step can be skipped if all atoms in this system are of the same type
+species = unique(atoms.Z)
+
+# Construct a pair of on and off-site bases
+on_site_basis = Basis(on_site_ace_basis(0, 1, 2, 4, 6.0; species = (try species catch nothing end)), (14, 3, 4))
+off_site_basis = Basis(off_site_ace_basis(1, 1, 1, 4, 8.0, 4.0; species = (try species catch nothing end)), (14, 14, 6, 6))
 
 # Gather all relevant data for fitting 
 on_site_data = get_dataset(H, atoms, on_site_basis, basis_definition, images)

--- a/docs/src/Getting_Started/Bases/Basis_Fitting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Fitting.md
@@ -17,6 +17,9 @@ end
 # Get the species of the system - it can be done in several ways and here just comes one
 # This step can be skipped if all atoms in this system are of the same type
 species = unique(atoms.Z)
+# Alternatively, one can use 
+# using JuLIP
+# species = [ keys(basis_definition)... ]
 
 # Construct a pair of on and off-site bases
 on_site_basis = Basis(on_site_ace_basis(0, 1, 2, 4, 6.0; species = (try species catch nothing end)), (14, 3, 4))

--- a/docs/src/Getting_Started/Bases/Basis_Fitting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Fitting.md
@@ -30,8 +30,11 @@ on_site_data = get_dataset(H, atoms, on_site_basis, basis_definition, images)
 off_site_data = get_dataset(H, atoms, off_site_basis, basis_definition, images)
 
 # Perform the fitting operation
-fit!(on_site_basis, on_site_data)
-fit!(off_site_basis, off_site_data)
+# Here, solver is an optional field with default "LSQR" which 
+# specifies the solver used to solve the least squares in fitting
+# Other possible choice are "ARD", "BRR", "RRQR" etc.
+fit!(on_site_basis, on_site_data; solver = "LSQR")
+fit!(off_site_basis, off_site_data; solver = "LSQR")
 
 ```
 

--- a/docs/src/Getting_Started/Bases/Basis_Fitting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Fitting.md
@@ -32,7 +32,7 @@ off_site_data = get_dataset(H, atoms, off_site_basis, basis_definition, images)
 # Perform the fitting operation
 # Here, solver is an optional field with default "LSQR" which 
 # specifies the solver used to solve the least squares in fitting
-# Other possible choice are "ARD", "BRR", "RRQR" etc.
+# Other possible choice are "QR", "ARD", "BRR", "RRQR" etc.
 fit!(on_site_basis, on_site_data; solver = "LSQR")
 fit!(off_site_basis, off_site_data; solver = "LSQR")
 

--- a/docs/src/Getting_Started/Model/Model_Fitting.md
+++ b/docs/src/Getting_Started/Model/Model_Fitting.md
@@ -16,7 +16,10 @@ h5open(database_path) do database
     systems = [database[target_system] for target_system in target_systems]
 
     # Perform the fitting operation
-    fit!(model, systems; recentre=true)
+    # Here, solver is an optional field with default "LSQR" which 
+    # specifies the solver used to solve the least squares in fitting
+    # Other possible choice are "QR", "ARD", "BRR", "RRQR" etc.
+    fit!(model, systems; recentre=true, solver = "LSQR")
 end
 
 # Don't forget to save the model after fitting (if needed)

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -241,7 +241,7 @@ function fit!(
     tolerance::Union{F, Nothing}=nothing,
     recentre::Bool=false, 
     target::Union{String, Nothing}=nothing, 
-    refit::Bool=false) where F<:AbstractFloat
+    refit::Bool=false, solver = "LSQR") where F<:AbstractFloat
     
     # Todo:
     #   - Add fitting parameters options which uses a `Params` instance to define fitting
@@ -299,7 +299,7 @@ function fit!(
     end
 
     # Fit the on/off-site models
-    fit!(model, fitting_data; refit=refit)
+    fit!(model, fitting_data; refit=refit, solver = solver)
     
 end
 
@@ -319,7 +319,7 @@ Fit the specified model using the provided data.
   can be suppressed by setting `refit=true`.
 """
 function fit!(
-    model::Model, fitting_data; refit::Bool=false)
+    model::Model, fitting_data; refit::Bool=false, solver="LSQR")
 
     @debug "Fitting off site bases:"
     for (id, basis) in model.off_site_bases
@@ -331,7 +331,7 @@ function fit!(
             @debug "Skipping $(id): fitting dataset is empty"
         else
             @debug "Fitting $(id): using $(length(fitting_data[id])) fitting points"
-            fit!(basis, fitting_data[id])
+            fit!(basis, fitting_data[id]; solver = solver)
         end    
     end
 
@@ -345,7 +345,7 @@ function fit!(
             @debug "Skipping $(id): fitting dataset is empty"
         else
             @debug "Fitting $(id): using $(length(fitting_data[id])) fitting points"
-            fit!(basis, fitting_data[id]; enable_mean=ison(basis))
+            fit!(basis, fitting_data[id]; enable_mean=ison(basis), solver = solver)
         end    
     end
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -88,7 +88,6 @@ struct Model
                         @debug "Building on-site model : $id"
                         ace_basis = ace_basis_on( # On-site bases
                             ℓ₁, ℓ₂, on_site_parameters[id]...; species = species)
-                        #TODO: add species to the above line
 
                         on_sites[(zᵢ, n₁, n₂)] = AHBasis(ace_basis, id)
                     end
@@ -98,7 +97,6 @@ struct Model
 
                     ace_basis = ace_basis_off( # Off-site bases
                         ℓ₁, ℓ₂, off_site_parameters[id]...; species = species)
-                    #TODO: add species to the above line
                     
                     @static if DUAL_BASIS_MODEL
                         if homo_atomic && n₁ == n₂

--- a/src/models.jl
+++ b/src/models.jl
@@ -5,6 +5,9 @@ import ACEbase: read_dict, write_dict
 using ACEhamiltonians.Parameters: OnSiteParaSet, OffSiteParaSet
 using ACEhamiltonians.Bases: AHBasis, is_fitted
 using ACEhamiltonians: DUAL_BASIS_MODEL
+# Once we change the keys of basis_def from Integer to AtomicNumber, we will no 
+# longer need JuLIP here 
+using JuLIP
 
 
 export Model
@@ -51,12 +54,16 @@ struct Model
         # Developers Notes
         # This makes the assumption that all z₁-z₂-ℓ₁-ℓ₂ interactions are represented
         # by the same model.
+        
+        # get a species list from basis_definition 
+        species = AtomicNumber.([ keys(basis_definition)... ])
+        
         # Discuss use of the on/off_site_cache entities
 
         on_sites = Dict{NTuple{3, keytype(basis_definition)}, AHBasis}()
         off_sites = Dict{NTuple{4, keytype(basis_definition)}, AHBasis}()
         
-        # Caching the basis functions of the functions is faster and allows ust to reuse
+        # Caching the basis functions of the functions is faster and allows us to reuse
         # the same basis function for similar interactions.
         ace_basis_on = with_cache(on_site_ace_basis)
         ace_basis_off = with_cache(off_site_ace_basis)
@@ -80,7 +87,7 @@ struct Model
                         id = (zᵢ, n₁, n₂)
                         @debug "Building on-site model : $id"
                         ace_basis = ace_basis_on( # On-site bases
-                            ℓ₁, ℓ₂, on_site_parameters[id]...)
+                            ℓ₁, ℓ₂, on_site_parameters[id]...; species = species)
                         #TODO: add species to the above line
 
                         on_sites[(zᵢ, n₁, n₂)] = AHBasis(ace_basis, id)
@@ -90,7 +97,7 @@ struct Model
                     @debug "Building off-site model: $id"
 
                     ace_basis = ace_basis_off( # Off-site bases
-                        ℓ₁, ℓ₂, off_site_parameters[id]...)
+                        ℓ₁, ℓ₂, off_site_parameters[id]...; species = species)
                     #TODO: add species to the above line
                     
                     @static if DUAL_BASIS_MODEL


### PR DESCRIPTION
This PR enables multi-species fitting at the `Model` level.

It also updates the documentation a bit to allow species in the Basis_Fitting step.

One thing I am thinking (and Adam also mentioned) is whether or not we should make the keyword of `basis_definition` AtomicNumbers instead of Integers so that things look more consistent.