### PR TITLE
Renaming (Basis -> SubModel)

### DIFF
--- a/docs/src/Getting_Started/Bases/Basis_Construction.md
+++ b/docs/src/Getting_Started/Bases/Basis_Construction.md
@@ -1,4 +1,4 @@
-# Basis Construction
+# SubModel Construction
 Individual on and off site bases may be constructed via calls to the `on_site_ace_basis` and `off_site_ace_basis` functions respectively. For on-site bases, one must specify six arguments:
 
  -  The azimuthal quantum numbers of the associated shells, `ℓ₁` and `ℓ₂`. For example, `ℓ₁, ℓ₂= 0, 1` would correspond to a s-p interaction.
@@ -12,7 +12,7 @@ Individual on and off site bases may be constructed via calls to the `on_site_ac
 ν, deg = 2, 4
 e_cut, r0 = 12.0, 2.5
 
-on_site_core_basis = on_site_ace_basis(ℓ₁, ℓ₂, ν, deg, e_cut, r0)
+on_site_ss_basis = on_site_ace_basis(ℓ₁, ℓ₂, ν, deg, e_cut, r0)
 ```
 
 The call to the off-site basis constructor is identical to its on-site counterpart. With the exception that a bond distance cutoff is provided in-place of `r0`. Which, as it name suggests, specifies the maximum distance up to which such interactions will be considered. That is to say only interactions between pairs of atoms separated by a distance less than or equal to `b_cut` will be evaluated. For off-site interactions the body-order is two greater than the correlation order. 
@@ -21,16 +21,17 @@ The call to the off-site basis constructor is identical to its on-site counterpa
 ν, deg = 1, 4
 b_cut, e_cut = 12.0, 5.0
 
-off_site_core_basis = off_site_ace_basis(ℓ₁, ℓ₂, ν, deg, b_cut, e_cut)
+off_site_sp_basis = off_site_ace_basis(ℓ₁, ℓ₂, ν, deg, b_cut, e_cut)
 ```
 
-In order to make use of the these bases one must wrap them in a `Basis` instance like so:
+To predict a subblock of the Hamiltonian, one may need the above basis, and fit the coefficients of it from data.
+This can be done by wrapping them in a `SubModel` instance like so:
 ```julia
 id_on = (6, 1, 1)
 id_off = (6, 6, 1, 2)
-on_site_ss_basis = Basis(on_site_core_basis, id_on)
-off_site_sp_basis = Basis(off_site_core_basis, id_off)
+on_site_ss_basis = SubModel(on_site_ss_basis, id_on)
+off_site_sp_basis = SubModel(off_site_sp_basis, id_off)
 ```
 The first argument is always the `SymmetricBasis` object returned by the on/off-site ACE basis constructor functions. The second argument is the basis `id`, this is used to identify what interaction the basis is associated with. An `id` of the form `(z, i, j)` indicates a basis represent the on-site interaction between the `i`ᵗʰ and `j`ᵗʰ shells of species `z`. Whereas an `id` of the form `(z₁, z₂, i, j)` indicates the basis represents an off-site interaction between the `i`ᵗʰ shell of species `z₁` and the `j`ᵗʰ shell of species `z₂`. Shell indices are used in place of azimuthal quantum numbers to avoid ambiguities arising from the use of non-minimal basis sets.
 
-These `Basis` structures contain for members, `basis`, `id`, `coefficients` and `mean`. With the first two already having been discussed. The latter two `coefficients` and `mean` are set during the fitting process and are used only when making predictions.
+Like all other models do, these `SubModel` structures contain four members, `basis`, `id`, `coefficients` and `mean`. With the first two already having been discussed. The latter two `coefficients` and `mean` are set during the fitting process and are used only when making predictions.

--- a/docs/src/Getting_Started/Bases/Basis_Fitting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Fitting.md
@@ -1,5 +1,5 @@
-# Basis Fitting
-Individual `Basis` instances may be fitted by supplying the `Basis` and fitting `data` to the `fit!` function. This single basis `fit!` function takes the two aforementioned positional arguments along with three optional keyword arguments: `solver` which specifies the solver to use during fitting which defaults to `LSQR`, `λ` is the degree of regularisation to be applied which defaults to `1E-7`, and `enable_mean` with permits a mean offset to be applied while this defaults to `false` it is advised to enable it when fitting on-site bases.
+# SubModel Fitting
+Individual `SubModel` instances may be fitted by supplying the `SubModel` and fitting `data` to the `fit!` function. This single basis `fit!` function takes the two aforementioned positional arguments along with three optional keyword arguments: `solver` which specifies the solver to use during fitting which defaults to `LSQR`, `λ` is the degree of regularisation to be applied which defaults to `1E-7`, and `enable_mean` with permits a mean offset to be applied while this defaults to `false` it is advised to enable it when fitting on-site bases.
 ```julia
 
 # Path to the database within which the fitting data is stored
@@ -21,20 +21,20 @@ species = unique(atoms.Z)
 # using JuLIP
 # species = AtomicNumber.([ keys(basis_definition)... ])
 
-# Construct a pair of on and off-site bases
-on_site_basis = Basis(on_site_ace_basis(0, 1, 2, 4, 6.0; species = (try species catch nothing end)), (14, 3, 4))
-off_site_basis = Basis(off_site_ace_basis(1, 1, 1, 4, 8.0, 4.0; species = (try species catch nothing end)), (14, 14, 6, 6))
+# Construct a pair of on and off-site model
+on_site_sp_model = SubModel(on_site_ace_basis(0, 1, 2, 4, 6.0; species = (try species catch nothing end)), (14, 3, 4))
+off_site_pp_model = SubModel(off_site_ace_basis(1, 1, 1, 4, 8.0, 4.0; species = (try species catch nothing end)), (14, 14, 6, 6))
 
 # Gather all relevant data for fitting 
-on_site_data = get_dataset(H, atoms, on_site_basis, basis_definition, images)
-off_site_data = get_dataset(H, atoms, off_site_basis, basis_definition, images)
+on_site_sp_data = get_dataset(H, atoms, on_site_sp_model, basis_definition, images)
+off_site_pp_data = get_dataset(H, atoms, off_site_pp_model, basis_definition, images)
 
 # Perform the fitting operation
 # Here, solver is an optional field with default "LSQR" which 
 # specifies the solver used to solve the least squares in fitting
 # Other possible choice are "QR", "ARD", "BRR", "RRQR" etc.
-fit!(on_site_basis, on_site_data; solver = "LSQR")
-fit!(off_site_basis, off_site_data; solver = "LSQR")
+fit!(on_site_sp_model, on_site_sp_data; solver = "LSQR")
+fit!(off_site_pp_model, off_site_pp_data; solver = "LSQR")
 
 ```
 

--- a/docs/src/Getting_Started/Bases/Basis_Predicting.md
+++ b/docs/src/Getting_Started/Bases/Basis_Predicting.md
@@ -1,5 +1,5 @@
-# Basis Predicting
-Predictions can be made for individual bases by providing a `Basis` instance along with a state-vector (a vector of `AbstractState` instance) to the `predict` function.
+# SubModel Predicting
+Predictions can be made for individual bases by providing a `SubModel` instance along with a state-vector (a vector of `AbstractState` instance) to the `predict` function.
 ```julia
 
 
@@ -17,11 +17,10 @@ on_site_state = get_state(1, atoms)
 
 # Get the off-site state representing the environment about the bond
 # between atom 1 in the origin cell and atom 2 in image [0, 0, 1].
-off_site_state = get_state(1, 2, atoms, envelope(off_site_basis), [0, 0, 1])
+off_site_state = get_state(1, 2, atoms, envelope(off_site_pp_model), [0, 0, 1])
 
 # Make the predictions
-on_site_block = predict(on_site_basis, on_site_state)
-off_site_block = predict(off_site_basis, off_site_state)
+on_site_sp_block = predict(on_site_sp_basis, on_site_state)
+off_site_pp_block = predict(off_site_pp_basis, off_site_state)
 ```
 Predictions can also be made for multiple blocks simultaneously by providing a vector containing multiple state-vectors.
-

--- a/docs/src/Getting_Started/Quick_Start.md
+++ b/docs/src/Getting_Started/Quick_Start.md
@@ -7,8 +7,8 @@
 The `ACEhamiltonians` package is a `Julia` package that provides tools for constructing, fitting, and predicting self-consistent Hamiltonian and overlap matrices in solid-state systems. It is based on the atomic cluster expansion (ACE) approach and the associated [ACEsuit package](https://github.com/ACEsuit/ACE.jl). The `ACEhamiltonians` package contains functions for generating on-site and off-site basis functions, fitting these bases to theoretical (DFT) data, and predicting the Hamiltonian and overlap matrices for any atomic configuration in real or reciprocal space. `ACEhamiltonians` provides a flexible and efficient way to model the electronic structure of materials and is a valuable tool for researchers in computational materials science. Please refer to the associated [article](https://www.nature.com/articles/s41524-022-00843-2) for a more in-depth description of the methodological underpinnings of this package.
 
 # Getting Started
-This quick-start guide provides an overview of the `ACEhamiltonians` framework, including the `Model` and `Basis` structures.
-The `Model` structure represents a model that includes on-site and off-site bases, their corresponding parameters, and the basis definition, while the `Basis` structures within represents the interaction between atomic shells in a system.
+This quick-start guide provides an overview of the `ACEhamiltonians` framework, including the `Model` and `SubModel` structures.
+The `Model` structure represents a model that includes on-site and off-site bases, their corresponding parameters, and the basis definition, while the `SubModel` structures within represents the interaction between atomic shells in a system.
 The guide outlines the construction, fitting, and predicting processes for both structures, providing users with an efficient and flexible way to represent interactions in various systems.
 Links to more detailed documents are also provided as necessary.
 
@@ -63,22 +63,24 @@ You can use the `cell_translations` method to estimate them based on the distanc
 
 
 
-## Bases
-The `Basis` structure is a key component of the `ACEHamiltonians` framework, representing the interaction between atomic shells in a system.
-It is constructed from on-site or off-site ACE basis functions and contains a unique identifier (`id`) for the specific interaction.
-Once fitted, the `Basis` structure holds `coefficients` and `mean` values used for making predictions.
+## SubModels
+Instead of constructing, fitting and preficting with the `Model` structure, whose input and output are both whole Hamiltonian, the `SubModel` structure gives the users 
+more flexibility in terms of subblock fitting. 
+It is nevertheless another key component of the `ACEHamiltonians` framework, representing the interaction between atomic shells in a system.
+To use this structure, one start with constructibg on-site or off-site ACE basis and specifying a unique identifier (`id`) for the specific interaction.
+Once fitted(with the help of data), the `SubModel` structure holds `coefficients` and `mean` values used for making predictions.
 It is a flexible and efficient way to represent interactions in various systems, making it an essential part of the model fitting and prediction process.
 
-Typically, creating isolated `Basis` instances isn't commonly required, as the `Model` encompasses the essential functionality for constructing and applying bases. However, working with individual Basis instances can be beneficial during hyperparameter optimization and are therefore discussed here.
+Typically, creating isolated `SubModel` instances isn't commonly required, as the `Model` encompasses the essential functionality for constructing and applying bases. However, working with individual SubModel instances can be beneficial during hyperparameter optimization and are therefore discussed here.
 
 
-The [`Basis Construction`](Bases/Basis_Construction.md) section explains how to create individual on-site and off-site bases using the `on_site_ace_basis` and `off_site_ace_basis` functions, respectively. The process involves specifying necessary parameters such as quantum numbers, correlation order, maximum polynomial degree, and cutoff distances. After creating the core basis, it is wrapped in a `Basis` instance, which associates the basis with an interaction and provides an identifier. The `Basis` structure is utilized during the fitting process and when making predictions.
+The [`SubModel Construction`](Bases/Basis_Construction.md) section explains how to create individual on-site and off-site bases using the `on_site_ace_basis` and `off_site_ace_basis` functions, respectively. The process involves specifying necessary parameters such as quantum numbers, correlation order, maximum polynomial degree, and cutoff distances. After creating the core basis, it is wrapped in a `SubModel` instance, which associates the basis with an interaction and provides an identifier. The `SubModel` structure is utilised during the fitting process and when making predictions.
 
 
-The [`Basis Fitting`](Bases/Basis_Fitting.md) section explains how to fit individual `Basis` instances by providing the basis and fitting data to the `fit!` function. The function requires a `DataSet` instance containing all necessary data for the fitting process. The `get_dataset` convenience function automatically collects all relevant data, simplifying the fitting operation. The fitting process involves loading the real-space Hamiltonian matrix, atoms object, cell translation vectors, and basis set definition, and then performing the fitting operation on the bases.
+The [`SubModel Fitting`](Bases/Basis_Fitting.md) section explains how to fit individual `SubModel` instances by providing the basis and fitting data to the `fit!` function. The function requires a `DataSet` instance containing all necessary data for the fitting process. The `get_dataset` convenience function automatically collects all relevant data, simplifying the fitting operation. The fitting process involves loading the real-space Hamiltonian matrix, atoms object, cell translation vectors, and basis set definition, and then performing the fitting operation on the bases.
 
 
-The [`Basis Predicting`](Bases/Basis_Predicting.md) section describes how to make predictions for individual bases using the `predict` function. By providing a `Basis` instance and a state-vector (a vector of `AbstractState` instances), predictions can be made for on-site and off-site interactions. The example demonstrates how to load an atoms object, obtain the on-site and off-site states representing the environment, and make predictions for these states. Predictions can also be made for multiple blocks simultaneously by providing a vector containing multiple state-vectors.
+The [`SubModel Predicting`](Bases/Basis_Predicting.md) section describes how to make predictions for individual bases using the `predict` function. By providing a `SubModel` instance and a state-vector (a vector of `AbstractState` instances), predictions can be made for on-site and off-site interactions. The example demonstrates how to load an atoms object, obtain the on-site and off-site states representing the environment, and make predictions for these states. Predictions can also be made for multiple blocks simultaneously by providing a vector containing multiple state-vectors.
 
 
 # Installation and Setup

--- a/src/datastructs.jl
+++ b/src/datastructs.jl
@@ -448,11 +448,11 @@ function get_dataset(
     basis_def = model.basis_definition
     on_site_data = Dict(
         basis.id => get_dataset(matrix, atoms, basis, basis_def, images; kwargs...)
-        for basis in values(model.on_site_bases))
+        for basis in values(model.on_site_submodels))
 
     off_site_data = Dict(
         basis.id => get_dataset(matrix, atoms, basis, basis_def, images; kwargs...)
-        for basis in values(model.off_site_bases))
+        for basis in values(model.off_site_submodels))
 
     return on_site_data, off_site_data
 end

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -272,7 +272,7 @@ function fit!(
         images = ndims(matrix) == 2 ? nothing : load_cell_translations(system)
         
         # Loop over the on site bases and collect the appropriate data
-        for basis in values(model.on_site_bases)
+        for basis in values(model.on_site_submodels)
             data_set = get_dataset(matrix, atoms, basis, model.basis_definition, images;
                 tolerance=tolerance)
 
@@ -286,7 +286,7 @@ function fit!(
         end 
 
         # Repeat for the off-site models
-        for basis in values(model.off_site_bases)
+        for basis in values(model.off_site_submodels)
             data_set = get_dataset(matrix, atoms, basis, model.basis_definition, images;
                 tolerance=tolerance, filter_bonds=true)
         
@@ -322,7 +322,7 @@ function fit!(
     model::Model, fitting_data; refit::Bool=false, solver="LSQR")
 
     @debug "Fitting off site bases:"
-    for (id, basis) in model.off_site_bases
+    for (id, basis) in model.off_site_submodels
         if !haskey(fitting_data, id)
             @debug "Skipping $(id): no fitting data provided"
         elseif is_fitted(basis) && !refit
@@ -336,7 +336,7 @@ function fit!(
     end
 
     @debug "Fitting on site bases:"
-    for (id, basis) in model.on_site_bases
+    for (id, basis) in model.on_site_submodels
         if !haskey(fitting_data, id)
             @debug "Skipping $(id): no fitting data provided"
         elseif is_fitted(basis) && !refit
@@ -388,7 +388,7 @@ function old_fit!(
         # Loop over the on site bases and collect the appropriate data
         if haskey(index_data, "atomic_indices")
             println("Gathering on-site data:")
-            for basis in values(model.on_site_bases)
+            for basis in values(model.on_site_submodels)
                 println("\t- $basis")
                 data_set = get_dataset(
                     matrix, atoms, basis, model.basis_definition;
@@ -402,7 +402,7 @@ function old_fit!(
         # Repeat for the off-site models
         if haskey(index_data, "atom_block_indices")
             println("Gathering off-site data:")
-            for basis in values(model.off_site_bases)
+            for basis in values(model.off_site_submodels)
                 println("\t- $basis")
                 data_set = get_dataset(
                     matrix, atoms, basis, model.basis_definition;

--- a/src/predicting.jl
+++ b/src/predicting.jl
@@ -251,7 +251,7 @@ function _predict(model, atoms, cell_indices)
 
             
             # Get the off-site basis associated with this interaction
-            basis_off = model.off_site_bases[(species₁, species₂, shellᵢ, shellⱼ)]
+            basis_off = model.off_site_submodels[(species₁, species₂, shellᵢ, shellⱼ)]
 
             # Identify off-site sub-blocks with bond-distances less than the specified cutoff
             off_blockᵢ = filter_idxs_by_bond_distance(
@@ -285,7 +285,7 @@ function _predict(model, atoms, cell_indices)
             # to approximate the on-site sub-blocks as identify matrices.
             if species₁ ≡ species₂ && model.label ≠ "S"
                 # Get the on-site basis and construct the on-site states
-                basis_on = model.on_site_bases[(species₁, shellᵢ, shellⱼ)]
+                basis_on = model.on_site_submodels[(species₁, shellᵢ, shellⱼ)]
                 on_site_states = _get_states(on_blockᵢ, atoms; r=radial(basis_on).R.ru)
                 
                 # Don't try to compute on-site interactions if none exist
@@ -338,7 +338,7 @@ function _predict(model, atoms)
 
         for (shellᵢ, shellⱼ) in shell_pairs(species₁, species₂, basis_def)
 
-            basis_off = model.off_site_bases[(species₁, species₂, shellᵢ, shellⱼ)]
+            basis_off = model.off_site_submodels[(species₁, species₂, shellᵢ, shellⱼ)]
 
             off_blockᵢ = filter_idxs_by_bond_distance(
                 filter_off_site_idxs(blockᵢ), 
@@ -366,7 +366,7 @@ function _predict(model, atoms)
 
             
             if species₁ ≡ species₂ && model.label ≠ "S"
-                basis_on = model.on_site_bases[(species₁, shellᵢ, shellⱼ)]
+                basis_on = model.on_site_submodels[(species₁, shellᵢ, shellⱼ)]
                 on_site_states = _get_states(on_blockᵢ, atoms; r=radial(basis_on).R.ru)
                 
 
@@ -439,7 +439,7 @@ function _maximum_distance_estimation(model::Model)
     # Maximum effective envelope distance 
     max₃ = maximum(
         [sqrt((env.r0cut + env.zcut)^2 + (env.rcut/2)^2)
-        for env in envelope.(values(model.off_site_bases))])
+        for env in envelope.(values(model.off_site_submodels))])
     
     return max(max₁, max₂, max₃)
 

--- a/test/unit_tests/test_bases_simple.jl
+++ b/test/unit_tests/test_bases_simple.jl
@@ -39,14 +39,14 @@ end
 
 
 function _get_off_site_dict(model)
-    # This just returns the model.off_site_bases filed with with the
+    # This just returns the model.off_site_submodels filed with with the
     # id key swapped out for a more visually intuitive string
     bases = Dict()
 
     basis_definition = model.basis_definition
 
     bases = Dict()
-    for (id, basis) in model.off_site_bases
+    for (id, basis) in model.off_site_submodels
         i , j  = id[end-1:end]
         ℓ₁, ℓ₂ = basis_definition[id[1]][i], basis_definition[id[2]][j]
         name = "$(_l2s(ℓ₁))$(_subscript(i))$(_l2s(ℓ₂))$(_subscript(j))"
@@ -58,14 +58,14 @@ end
 
 
 function _get_on_site_dict(model)
-    # This just returns the model.off_site_bases filed with with the
+    # This just returns the model.off_site_submodels filed with with the
     # id key swapped out for a more visually intuitive string
     bases = Dict()
 
     basis_definition = model.basis_definition
 
     bases = Dict()
-    for (id, basis) in model.on_site_bases
+    for (id, basis) in model.on_site_submodels
         i , j  = id[end-1:end]
         ℓ₁, ℓ₂ = basis_definition[id[1]][i], basis_definition[id[1]][j]
         name = "$(_l2s(ℓ₁))$(_subscript(i))$(_l2s(ℓ₂))$(_subscript(j))"
@@ -342,22 +342,22 @@ end
     
         # Extract the off site basis dictionary and swap out the key for a more
         # visually meaningful string to help with debugging.
-        off_site_bases = _get_off_site_dict(model)
+        off_site_submodels = _get_off_site_dict(model)
     
         
-        _check_contrived_system_1(off_site_bases, basis_definition, database_path; tol=off_site_tol)
-        _check_contrived_system_2(off_site_bases, basis_definition, database_path; tol=off_site_tol)
-        _check_contrived_system_3(off_site_bases, basis_definition, database_path; tol=off_site_tol)
-        _check_contrived_system_4(off_site_bases, basis_definition, database_path; tol=off_site_tol)
+        _check_contrived_system_1(off_site_submodels, basis_definition, database_path; tol=off_site_tol)
+        _check_contrived_system_2(off_site_submodels, basis_definition, database_path; tol=off_site_tol)
+        _check_contrived_system_3(off_site_submodels, basis_definition, database_path; tol=off_site_tol)
+        _check_contrived_system_4(off_site_submodels, basis_definition, database_path; tol=off_site_tol)
     
     end
 
     @testset "On-site Contrived Tolerance Check" begin
         # No symmetry tests are required here thus only a tolerance check is
         # performed on one of the contrived systems.
-        on_site_bases = _get_on_site_dict(model)
+        on_site_submodels = _get_on_site_dict(model)
 
-        _check_on_site(on_site_bases, basis_definition, database_path; tol=on_site_tol)
+        _check_on_site(on_site_submodels, basis_definition, database_path; tol=on_site_tol)
         
     end
 


### PR DESCRIPTION
Rename `Basis` to `SubModel` and modify the corresponding parts (tutorial included). 